### PR TITLE
Feature/add memory test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,6 @@
   :repositories {"conjars" "http://conjars.org/repo/"}
   :dev-dependencies [[midje "1.3.1" :exclusions [org.clojure/clojure]]
                      [org.clojure/clojure "1.2.1"]
-                     [org.apache.thrift/libthrift "0.6.1"]
-                     [com.google.protobuf/protobuf-java "2.4.0a"]
                      [org.apache.hadoop/hadoop-core "0.20.2-dev"]
                      [cascading/cascading-hadoop "2.0.0-wip-234"
                       :exclusions [org.codehaus.janino/janino

--- a/test/com/twitter/maple/tap/memory_test.clj
+++ b/test/com/twitter/maple/tap/memory_test.clj
@@ -1,0 +1,46 @@
+(ns com.twitter.maple.tap.memory-test
+  (:require [clojure.string :as s])
+  (:import [java.util ArrayList]
+           [com.twitter.maple.tap MemorySourceTap]
+           [cascading.tuple Fields]
+           [cascading.flow.hadoop HadoopFlowProcess]
+           [org.apache.hadoop.mapred JobConf]))
+
+(def ^:dynamic *default-conf* {})
+
+(def defaults
+  {"io.serializations"
+   (s/join "," ["org.apache.hadoop.io.serializer.WritableSerialization"
+                "cascading.tuple.hadoop.TupleSerialization"])})
+
+(def mk-props
+  (partial merge defaults))
+
+(defn job-conf
+  "Returns a JobConf instance, optionally augmented by the supplied
+   property map."
+  ([] (job-conf *default-conf*))
+  ([prop-map]
+     (let [conf (JobConf.)]
+       (doseq [[k v] (mk-props prop-map)]
+         (.set conf k v))
+       conf)))
+
+(defn tuple-seq
+  "Returns all tuples in the supplied cascading tap as a Clojure
+  sequence."
+  [tap]
+  (with-open [it (-> (HadoopFlowProcess. (job-conf))
+                     (.openTapForRead tap))]
+    (doall (for [wrapper (iterator-seq it)]
+             (into [] (.getTuple wrapper))))))
+
+(comment
+  "TODO: Implement coerceToTuple and fields."
+  (defn memory-tap
+    ([tuples] (memory-tap Fields/ALL tuples))
+    ([fields-in tuple-seq]
+       (let [tuples (->> tuple-seq
+                         (map #(Util/coerceToTuple %))
+                         (ArrayList.))]
+         (MemorySourceTap. tuples (fields fields-in))))))


### PR DESCRIPTION
Not familiar with the test framework, but the code is there (copied from the old meatlocker project).
# Currently it says:

Testing com.twitter.maple.tap.memory-test

Ran 0 tests containing 0 assertions.
0 failures, 0 errors.
