### PR TITLE
Added support for memory taps that are empty

### DIFF
--- a/src/jvm/com/twitter/maple/tap/TupleMemoryInputFormat.java
+++ b/src/jvm/com/twitter/maple/tap/TupleMemoryInputFormat.java
@@ -143,7 +143,14 @@ public class TupleMemoryInputFormat implements InputFormat<TupleWrapper, NullWri
         
         String[] pieces = s.split(":");
         int size = Integer.valueOf(pieces[0]);
-        byte[] val = decodeBytes(pieces[1]);
+        
+        byte[] val;
+        
+        if (pieces.length > 1){
+            val = decodeBytes(pieces[1]);
+        }else{
+            val = new byte[0];
+        }
 
         SerializationFactory factory = new SerializationFactory(conf);
         Deserializer<Tuple> deserializer = factory.getDeserializer(Tuple.class);


### PR DESCRIPTION
This is useful for testing scenarios with no tuples flowing through. It was supported in the Cascalog version of this a while back. This pull request prevents an ArrayIndexOutOfBoundsException that happens with the current version of maple.

Sending this pull request again to develop rather than master.
