### PR TITLE
Don't swallow errors when creating new HBase tables

### DIFF
--- a/src/jvm/com/twitter/maple/hbase/HBaseTap.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseTap.java
@@ -160,7 +160,7 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
       try {
           createResource(conf);
       } catch (IOException e) {
-          throw new RuntimeException(tableName + " does not exist !");
+          throw new RuntimeException(tableName + " does not exist !", e);
       }
 
     }


### PR DESCRIPTION
Hit this when trying to create a table without the proper config.  Error message said the table didn't exist, but hid the real reason (unable to connect to the HBase instance).
