### PR TITLE
Make getHBaseAdmin protected in HBaseTap

### DIFF
--- a/src/jvm/com/twitter/maple/hbase/HBaseTap.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseTap.java
@@ -130,7 +130,7 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
     return new Path(SCHEME + ":/" + tableName.replaceAll(":", "_"));
   }
 
-  private HBaseAdmin getHBaseAdmin(JobConf conf) throws MasterNotRunningException, ZooKeeperConnectionException {
+  protected HBaseAdmin getHBaseAdmin(JobConf conf) throws MasterNotRunningException, ZooKeeperConnectionException {
     if (hBaseAdmin == null) {
       Configuration hbaseConf = HBaseConfiguration.create(conf);
       hBaseAdmin = new HBaseAdmin(hbaseConf);


### PR DESCRIPTION
I add some metadata to the table once it has been created.  Making HBaseAdmin protected allows me to subclass the tap and add the metadata using the same HBaseAdmin instance.
