### PR TITLE
Adding a fixed deprecated TableInputFormat class.

### DIFF
--- a/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
@@ -12,6 +12,8 @@
 
 package com.twitter.maple.hbase;
 
+import com.twitter.maple.hbase.mapred.TableInputFormat;
+
 import cascading.flow.FlowProcess;
 import cascading.scheme.Scheme;
 import cascading.scheme.SinkCall;
@@ -24,7 +26,6 @@ import cascading.util.Util;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.mapred.TableInputFormat;
 import org.apache.hadoop.hbase.mapred.TableOutputFormat;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapred.JobConf;
@@ -147,7 +148,7 @@ public class HBaseScheme
       }
     } else {
       for (String familyName : familyNames) {
-        familyNameSet.add(familyName); 
+        familyNameSet.add(familyName);
       }
     }
     return familyNameSet.toArray(new String[0]);
@@ -212,7 +213,7 @@ public class HBaseScheme
     for (int i = 0; i < valueFields.length; i++) {
       Fields fieldSelector = valueFields[i];
       TupleEntry values = tupleEntry.selectEntry(fieldSelector);
-      
+
       for (int j = 0; j < values.getFields().size(); j++) {
         Fields fields = values.getFields();
         Tuple tuple = values.getTuple();

--- a/src/jvm/com/twitter/maple/hbase/HBaseTap.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseTap.java
@@ -212,19 +212,7 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
 
   @Override
   public boolean deleteResource(JobConf jobConf) throws IOException {
-    // eventually keep table meta-data to source table create
-    HBaseAdmin hBaseAdmin = getHBaseAdmin(jobConf);
-
-    if (!hBaseAdmin.tableExists(tableName)) {
-      return true;
-    }
-
-    // TODO: these lines look dangerous so commenting out
-    // LOG.info("deleting hbase table: {}", tableName);
-
-    // hBaseAdmin.disableTable(tableName);
-    // hBaseAdmin.deleteTable(tableName);
-
+    // TODO: for now we don't do anything just to be safe
     return true;
   }
 

--- a/src/jvm/com/twitter/maple/hbase/HBaseTap.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseTap.java
@@ -12,6 +12,8 @@
 
 package com.twitter.maple.hbase;
 
+import com.twitter.maple.hbase.mapred.TableInputFormat;
+
 import cascading.flow.FlowProcess;
 import cascading.tap.SinkMode;
 import cascading.tap.Tap;
@@ -25,7 +27,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
-import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
@@ -218,10 +219,11 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
       return true;
     }
 
-    LOG.info("deleting hbase table: {}", tableName);
+    // TODO: these lines look dangerous so commenting out
+    // LOG.info("deleting hbase table: {}", tableName);
 
-    hBaseAdmin.disableTable(tableName);
-    hBaseAdmin.deleteTable(tableName);
+    // hBaseAdmin.disableTable(tableName);
+    // hBaseAdmin.deleteTable(tableName);
 
     return true;
   }
@@ -244,7 +246,7 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
     }
 
     LOG.debug("sourcing from table: {}", tableName);
-    FileInputFormat.addInputPaths(conf, tableName);
+    TableInputFormat.setTableName(conf, tableName);
     super.sourceConfInit(process, conf);
   }
 

--- a/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
+++ b/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
@@ -90,7 +90,7 @@ public class TableInputFormat extends TableInputFormatBase implements
     // Make sure that table has not been set before
     String oldTableName = getTableName(job);
     if(oldTableName != null) {
-      throw new IOException("table name already set to: '"
+      throw new RuntimeException("table name already set to: '"
         + oldTableName + "'");
     }
     job.set(INPUT_TABLE, tableName);

--- a/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
+++ b/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2010 The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.twitter.maple.hbase.mapred;
+
+import java.io.IOException;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.mapred.TableInputFormatBase;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
+import org.apache.hadoop.util.StringUtils;
+
+/**
+ * Convert HBase tabular data into a format that is consumable by Map/Reduce.
+ */
+public class TableInputFormat extends TableInputFormatBase implements
+    JobConfigurable {
+  private final Log LOG = LogFactory.getLog(TableInputFormat.class);
+
+  /**
+   * space delimited list of columns
+   */
+  public static final String COLUMN_LIST = "hbase.mapred.tablecolumns";
+
+  /**
+   * Use this jobconf param to specify the input table
+   */
+  public static final String INPUT_TABLE = "hbase.mapred.inputtable";
+
+  public void configure(JobConf job) {
+    String tableName = TableInputFormat.getTableName(job);
+    String colArg = job.get(COLUMN_LIST);
+    String[] colNames = colArg.split(" ");
+    byte [][] m_cols = new byte[colNames.length][];
+    for (int i = 0; i < m_cols.length; i++) {
+      m_cols[i] = Bytes.toBytes(colNames[i]);
+    }
+    setInputColumns(m_cols);
+    try {
+      setHTable(new HTable(HBaseConfiguration.create(job), tableName));
+    } catch (Exception e) {
+      LOG.error(StringUtils.stringifyException(e));
+    }
+  }
+
+  public void validateInput(JobConf job) throws IOException {
+    // expecting exactly one path
+    String tableName = TableInputFormat.getTableName(job);
+    if (tableName == null) {
+      throw new IOException("expecting one table name");
+    }
+
+    // connected to table?
+    if (getHTable() == null) {
+      throw new IOException("could not connect to table '" +
+        tableName + "'");
+    }
+
+    // expecting at least one column
+    String colArg = job.get(COLUMN_LIST);
+    if (colArg == null || colArg.length() == 0) {
+      throw new IOException("expecting at least one column");
+    }
+  }
+
+  public static void setTableName(JobConf job, String tableName) {
+    // Make sure that table has not been set before
+    String oldTableName = getTableName(job);
+    if(oldTableName != null) {
+      throw new IOException("table name already set to: '"
+        + oldTableName + "'");
+    }
+    job.set(INPUT_TABLE, tableName);
+  }
+
+  public static String getTableName(JobConf job) {
+    return job.get(INPUT_TABLE);
+  }
+}


### PR DESCRIPTION
Currently the HBaseTap breaks if other sources are read in the same job. This is caused by a bug in the deprecated TableInputFormat class. The correct fix should be in HBase, however this is a temporary band aid.
