### PR TITLE
Fixed: missing qualifier causes a nullpointer exception to be thrown

### DIFF
--- a/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
@@ -191,6 +191,9 @@ public class HBaseScheme
         String fieldName = (String) fields.get(k);
         byte[] fieldNameBytes = Bytes.toBytes(fieldName);
         byte[] cellValue = row.getValue(familyNameBytes, fieldNameBytes);
+        if (cellValue == null) {
+            cellValue = new byte[0];
+        }
         result.add(new ImmutableBytesWritable(cellValue));
       }
     }


### PR DESCRIPTION
https://github.com/Cascading/maple/issues/30
