### PR TITLE
Remove the trailing semicolon so that Derby can use this untouched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /.project
 /.settings
 /bin/
+/bin

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /.classpath
 /.project
 /.settings
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /.lein-deps-sum
 /build
 /.gradle
+/.classpath
+/.project
+/.settings

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/build
+/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ apply plugin: 'maven'
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-group = "com.twitter"
+group = "com.twitter.eyt"
 archivesBaseName = 'maple'
-version = "0.2.8-SNAPSHOT++"
+version = "0.2.8.6"
 status = 'integration'
 
 
@@ -53,4 +53,29 @@ dependencies {
     exclude group: 'hadoop-core'
   }
   compile group: 'org.clojure', name: 'clojure', version: '1.2.1'
+}
+
+// Conjars target
+repoUrl = 'http://conjars.org/repo/'
+repoUserName = System.properties[ 'publish.repo.userName' ]
+repoPassword = System.properties[ 'publish.repo.password' ]
+
+uploadArchives {
+   repositories.mavenDeployer {
+      configuration = configurations.archives
+
+      repository( url : repoUrl ) {
+         authentication( userName: repoUserName, password: repoPassword )
+      }
+      pom.project {
+         description 'Updates to com.twitter.maple which provides a set of taps, including a JDBC, In-Memory, etc.'
+         licenses {
+            license {
+               name 'The Apache Software License, Version 2.0'
+               url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+               distribution 'repo'
+            }
+         }
+      }
+   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,8 @@ ext {
    repoUrl = 'http://conjars.org/repo/'
    repoUserName = System.properties[ 'publish.repo.userName' ]
    repoPassword = System.properties[ 'publish.repo.password' ]
+   if( System.properties[ 'publish.repo.url' ] )
+      repoUrl = System.properties[ 'publish.repo.url' ] 
 }
 
 uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,11 @@ dependencies {
 }
 
 // Conjars target
-repoUrl = 'http://conjars.org/repo/'
-repoUserName = System.properties[ 'publish.repo.userName' ]
-repoPassword = System.properties[ 'publish.repo.password' ]
+ext {
+   repoUrl = 'http://conjars.org/repo/'
+   repoUserName = System.properties[ 'publish.repo.userName' ]
+   repoPassword = System.properties[ 'publish.repo.password' ]
+}
 
 uploadArchives {
    repositories.mavenDeployer {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ defaultTasks 'assemble'
 
 apply plugin: 'maven'
 apply plugin: 'java'
+apply plugin: 'eclipse'
 
 group = "com.twitter"
 archivesBaseName = 'maple'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ configurations {
 repositories {
   mavenLocal()
   mavenCentral()
-  mavenRepo name: 'conjars', url: 'http://conjars.org/repo/'
+  maven {
+     url 'http://conjars.org/repo/'
+  }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'eclipse'
 
 group = "com.twitter.eyt"
 archivesBaseName = 'maple'
-version = "0.2.8.6"
+version = "0.2.8.7"
 status = 'integration'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,55 @@
+defaultTasks 'assemble'
+
+apply plugin: 'maven'
+apply plugin: 'java'
+
+group = "com.twitter"
+archivesBaseName = 'maple'
+version = "0.2.8-SNAPSHOT++"
+status = 'integration'
+
+
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
+sourceSets {
+  main {
+    java {
+      srcDir 'src/jvm'
+    }
+  }
+}
+
+configurations {
+}
+
+repositories {
+  mavenLocal()
+  mavenCentral()
+  mavenRepo name: 'conjars', url: 'http://conjars.org/repo/'
+}
+
+dependencies {
+  compile group: 'cascading', name: 'cascading-core', version: '2.1.5'
+  compile group: 'cascading', name: 'cascading-hadoop', version: '2.1.5'
+  compile group: 'cascading', name: 'cascading-local', version: '2.1.5' 
+
+  runtime group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
+  runtime group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.6.1'
+
+  // hadoop deps
+  compile( group: 'org.apache.hadoop', name: 'hadoop-core', version: '1.0.4' ) {
+    exclude group: 'ant'
+    exclude group: 'junit'
+  }
+
+  runtime group: 'org.apache.hadoop', name: 'hadoop-test', version: '1.0.4'
+  runtime group: 'commons-io', name: 'commons-io', version: '2.1'
+  runtime group: 'javax.ws.rs', name: 'jsr311-api', version: '1.1.1' 
+
+  compile ( group: 'org.apache.hbase', name: 'hbase', version: '0.94.5' ) {
+    exclude group: 'asm'
+    exclude group: 'hadoop-core'
+  }
+  compile group: 'org.clojure', name: 'clojure', version: '1.2.1'
+}

--- a/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseScheme.java
@@ -12,7 +12,20 @@
 
 package com.twitter.maple.hbase;
 
-import com.twitter.maple.hbase.mapred.TableInputFormat;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mapred.TableOutputFormat;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import cascading.flow.FlowProcess;
 import cascading.scheme.Scheme;
@@ -23,21 +36,8 @@ import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntry;
 import cascading.util.Util;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
-import org.apache.hadoop.hbase.mapred.TableOutputFormat;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.OutputCollector;
-import org.apache.hadoop.mapred.RecordReader;
-import org.mortbay.log.Log;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashSet;
+import com.twitter.maple.hbase.mapred.TableInputFormat;
 
 /**
  * The HBaseScheme class is a {@link Scheme} subclass. It is used in conjunction with the {@HBaseTap} to

--- a/src/jvm/com/twitter/maple/hbase/HBaseTap.java
+++ b/src/jvm/com/twitter/maple/hbase/HBaseTap.java
@@ -12,19 +12,16 @@
 
 package com.twitter.maple.hbase;
 
-import com.twitter.maple.hbase.mapred.TableInputFormat;
-
-import cascading.flow.FlowProcess;
-import cascading.tap.SinkMode;
-import cascading.tap.Tap;
-import cascading.tap.hadoop.io.HadoopTupleEntrySchemeCollector;
-import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
-import cascading.tuple.TupleEntryCollector;
-import cascading.tuple.TupleEntryIterator;
+import java.io.IOException;
+import java.util.UUID;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.*;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.MasterNotRunningException;
+import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.HBaseAdmin;
 import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 import org.apache.hadoop.mapred.FileInputFormat;
@@ -33,11 +30,15 @@ import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import java.io.IOException;
-import java.util.Map.Entry;
-import java.util.UUID;
+import cascading.flow.FlowProcess;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
+import cascading.tuple.TupleEntryCollector;
+import cascading.tuple.TupleEntryIterator;
+
+import com.twitter.maple.hbase.mapred.TableInputFormat;
 
 /**
  * The HBaseTap class is a {@link Tap} subclass. It is used in conjunction with

--- a/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
+++ b/src/jvm/com/twitter/maple/hbase/mapred/TableInputFormat.java
@@ -23,12 +23,10 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HTable;
 import org.apache.hadoop.hbase.mapred.TableInputFormatBase;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.util.StringUtils;

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -607,6 +607,14 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         return result;
     }
 
+    public void setInputFormatClass( Class<? extends DBInputFormat> inputFormatClass ) {
+        this.inputFormatClass = inputFormatClass;
+    }
+
+    public void setOutputFormatClass( Class<? extends DBOutputFormat> outputFormatClass ) {
+        this.outputFormatClass = outputFormatClass;
+    }
+
     @Override
     public boolean equals( Object object ) {
         if( this == object )

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -22,8 +22,10 @@ import cascading.tuple.Fields;
 import cascading.tuple.Tuple;
 import cascading.tuple.TupleEntry;
 import cascading.util.Util;
+
 import com.twitter.maple.jdbc.db.DBInputFormat;
 import com.twitter.maple.jdbc.db.DBOutputFormat;
+
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
@@ -44,8 +46,10 @@ import java.util.Arrays;
  * <p/>
  * Override this class, {@link DBInputFormat}, and {@link DBOutputFormat} to specialize for a given vendor database.
  */
+@SuppressWarnings("rawtypes")
 public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, Object[], Object[]>
 {
+    private static final long serialVersionUID = 2527660956910961832L;
     private Class<? extends DBInputFormat> inputFormatClass;
     private Class<? extends DBOutputFormat> outputFormatClass;
     private String[] columns;
@@ -623,6 +627,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         sourceCall.setContext( pair );
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean source( FlowProcess<JobConf> flowProcess, SourceCall<Object[], RecordReader> sourceCall ) throws IOException
     {
@@ -644,6 +649,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         sourceCall.setContext( null );
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void sink( FlowProcess<JobConf> flowProcess, SinkCall<Object[], OutputCollector> sinkCall ) throws IOException {
         // it's ok to use NULL here so the collector does not write anything

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -343,7 +343,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
         super.sinkConfInit( process, conf );
     }
 
-    private Connection createConnection()
+    protected Connection createConnection()
     {
         try
         {

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -68,19 +68,19 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
     private final String id = UUID.randomUUID().toString();
 
     /** Field connectionUrl */
-    String connectionUrl;
+    protected String connectionUrl;
     /** Field username */
-    String username;
+    protected String username;
     /** Field password */
-    String password;
+    protected String password;
     /** Field driverClassName */
-    String driverClassName;
+    protected String driverClassName;
     /** Field tableDesc */
-    TableDesc tableDesc;
+    protected TableDesc tableDesc;
     /** Field batchSize */
-    int batchSize = 1000;
+    protected int batchSize = 1000;
     /** Field concurrentReads */
-    int concurrentReads = 0;
+    protected int concurrentReads = 0;
 
     /**
      * Constructor JDBCTap creates a new JDBCTap instance.

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -274,7 +274,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
 
     private JobConf getSourceConf( FlowProcess<JobConf> flowProcess, JobConf conf, String property )
         throws IOException {
-        Map<String, String> priorConf = HadoopUtil.deserializeMapBase64( property, true );
+        Map<String, String> priorConf = HadoopUtil.deserializeBase64( property, conf, Map.class );
         return flowProcess.mergeMapIntoConfig( conf, priorConf );
     }
 

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -290,7 +290,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
         if( !isSink() )
             throw new TapException( "this tap may not be used as a sink, no TableDesc defined" );
 
-        LOG.info("Creating JDBCTapCollector output instance");
+        LOG.debug("Creating JDBCTapCollector output instance");
         JDBCTapCollector jdbcCollector = new JDBCTapCollector( flowProcess, this );
 
         jdbcCollector.prepare();
@@ -574,7 +574,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
 
         try
         {
-            LOG.info( "test table exists: {}", tableDesc.tableName );
+            LOG.debug( "test table exists: {}", tableDesc.tableName );
 
             executeQuery( tableDesc.getTableExistsQuery(), 0 );
         }

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -473,7 +473,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
         {
             try
             {
-                if ( ! success ) {
+                if ( connection != null && ! success ) {
                     connection.rollback();
                 }
                 if ( resultSet != null ) {

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTap.java
@@ -20,7 +20,9 @@ import cascading.tap.TapException;
 import cascading.tap.hadoop.io.HadoopTupleEntrySchemeIterator;
 import cascading.tuple.TupleEntryCollector;
 import cascading.tuple.TupleEntryIterator;
+
 import com.twitter.maple.jdbc.db.DBConfiguration;
+
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
@@ -61,7 +63,10 @@ import java.util.*;
  * @see com.twitter.maple.jdbc.db.DBInputFormat
  * @see com.twitter.maple.jdbc.db.DBOutputFormat
  */
+@SuppressWarnings("rawtypes")
 public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
+    private static final long serialVersionUID = -7243280650801344522L;
+
     /** Field LOG */
     private static final Logger LOG = LoggerFactory.getLogger(JDBCTap.class);
 
@@ -272,6 +277,7 @@ public class JDBCTap extends Tap<JobConf, RecordReader, OutputCollector> {
         return true;
     }
 
+    @SuppressWarnings({ "unused", "unchecked" })
     private JobConf getSourceConf( FlowProcess<JobConf> flowProcess, JobConf conf, String property )
         throws IOException {
         Map<String, String> priorConf = HadoopUtil.deserializeBase64( property, conf, Map.class );

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
@@ -77,6 +77,10 @@ public class JDBCTapCollector extends TupleEntrySchemeCollector implements Outpu
         super.prepare();
     }
 
+    public JobConf getJobConf() {
+        return conf;
+    }
+
     private void initialize() throws IOException {
         tap.sinkConfInit( hadoopFlowProcess, conf );
 

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
@@ -97,7 +97,7 @@ public class JDBCTapCollector extends TupleEntrySchemeCollector implements Outpu
     public void close() {
         try {
             LOG.info( "closing tap collector for: {}", tap );
-            writer.close( reporter );
+            if ( writer != null ) writer.close( reporter );
         } catch( IOException exception ) {
             LOG.warn( "exception closing: {}", exception );
             throw new TapException( "exception closing JDBCTapCollector", exception );

--- a/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCTapCollector.java
@@ -23,6 +23,7 @@ import cascading.flow.hadoop.HadoopFlowProcess;
 import cascading.tap.Tap;
 import cascading.tap.TapException;
 import cascading.tuple.TupleEntrySchemeCollector;
+
 import org.apache.hadoop.mapred.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,7 @@ import java.io.IOException;
  * Class JDBCTapCollector is a kind of {@link cascading.tuple.TupleEntrySchemeCollector} that writes tuples to the resource managed by
  * a particular {@link JDBCTap} instance.
  */
+@SuppressWarnings("rawtypes")
 public class JDBCTapCollector extends TupleEntrySchemeCollector implements OutputCollector
 {
     /** Field LOG */
@@ -56,6 +58,7 @@ public class JDBCTapCollector extends TupleEntrySchemeCollector implements Outpu
      * @param tap               of type Tap
      * @throws IOException when fails to initialize
      */
+    @SuppressWarnings("unchecked")
     public JDBCTapCollector( FlowProcess<JobConf> flowProcess, Tap<JobConf, RecordReader, OutputCollector> tap ) throws IOException {
         super( flowProcess, tap.getScheme() );
         this.hadoopFlowProcess = flowProcess;
@@ -81,6 +84,7 @@ public class JDBCTapCollector extends TupleEntrySchemeCollector implements Outpu
         return conf;
     }
 
+    @SuppressWarnings("unchecked")
     private void initialize() throws IOException {
         tap.sinkConfInit( hadoopFlowProcess, conf );
 
@@ -113,6 +117,7 @@ public class JDBCTapCollector extends TupleEntrySchemeCollector implements Outpu
      * @param writable           of type Writable
      * @throws IOException when
      */
+    @SuppressWarnings("unchecked")
     public void collect( Object writableComparable, Object writable ) throws IOException {
         if (hadoopFlowProcess instanceof HadoopFlowProcess)
             ((HadoopFlowProcess) hadoopFlowProcess).getReporter().progress();

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -62,10 +62,6 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
          */
         defaults = new JobConf();
 
-        // HACK: c.t.h.TextLine checks this property for .zip files; the check
-        // assumes the list is non-empty, which we mock up, here
-        defaults.set("mapred.input.dir", path);
-
         ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setDefaults(defaults);
 
         ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setTap(tap);

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -1,0 +1,211 @@
+package com.twitter.maple.jdbc;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+
+import com.twitter.maple.jdbc.JDBCTap;
+
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop.HadoopFlowProcess;
+import cascading.flow.hadoop.util.HadoopUtil;
+import cascading.scheme.Scheme;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tuple.TupleEntryCollector;
+import cascading.tuple.TupleEntryIterator;
+import cascading.util.Util;
+
+/**
+ * A shunt around the restrictions on taps that can run under the
+ * LocalFlowProcess. This class delegates to Lfs for all work, yet can run in
+ * Cascading local mode.
+ *
+ * Due to what appears to be a bug in LocalFlowStep#initTaps, schemes are not
+ * allowed to side-effect the properties passed to sourceConfInit and
+ * sinkConfInit. This appears to be a non-issue because local schemes never set
+ * any properties. overwriteProperties can likely be removed, but is kept in
+ * case custom local schemes eventually set properties (in a future release of
+ * Cascading where that's possible).
+ * 
+ * This is effectively a copy of the com.etsy.cascading.tap.local.LocalTap, but
+ * modified for the JDBCTap-ish.
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordReader, OutputCollector> {
+    private static final long serialVersionUID = 3480480638297770870L;
+
+    private static Logger LOG = Logger.getLogger(LocalJDBCTap.class.getName());
+
+    private JobConf defaults;
+    private JDBCTap lfs;
+    private final String path;
+
+    public LocalJDBCTap(Scheme scheme,
+            SinkMode sinkMode, JDBCTap tap, String path) {
+        super(new LocalScheme<SourceCtx, SinkCtx>(scheme), sinkMode);
+        this.lfs = tap;
+        this.path = path;
+        setup();
+    }
+
+    private void setup() {
+        /*
+         * LocalJDBCTap requires your system Hadoop configuration for defaults to
+         * supply the wrapped Lfs. Make sure you have your serializations and
+         * serialization tokens defined there.
+         */
+        defaults = new JobConf();
+
+        // HACK: c.t.h.TextLine checks this property for .zip files; the check
+        // assumes the list is non-empty, which we mock up, here
+        defaults.set("mapred.input.dir", path);
+
+        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setDefaults(defaults);
+
+        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setTap(lfs);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return path;
+    }
+
+    @Override
+    public TupleEntryIterator openForRead(FlowProcess<Properties> flowProcess, RecordReader input) throws IOException {
+        JobConf jobConf = mergeDefaults("LocalJDBCTap#openForRead", flowProcess.getConfigCopy(), defaults);
+        return lfs.openForRead(new HadoopFlowProcess(jobConf));
+    }
+
+    @Override
+    public TupleEntryCollector openForWrite(FlowProcess<Properties> flowProcess, OutputCollector output)
+            throws IOException {
+        JobConf jobConf = mergeDefaults("LocalJDBCTap#openForWrite", flowProcess.getConfigCopy(), defaults);
+        return lfs.openForWrite(new HadoopFlowProcess(jobConf));
+    }
+
+    @Override
+    public boolean createResource(Properties conf) throws IOException {
+        return lfs.createResource(mergeDefaults("LocalJDBCTap#createResource", conf, defaults));
+    }
+
+    @Override
+    public boolean deleteResource(Properties conf) throws IOException {
+        return lfs.deleteResource(mergeDefaults("LocalJDBCTap#deleteResource", conf, defaults));
+    }
+
+    @Override
+    public boolean resourceExists(Properties conf) throws IOException {
+        return lfs.resourceExists(mergeDefaults("LocalJDBCTap#resourceExists", conf, defaults));
+    }
+
+    @Override
+    public long getModifiedTime(Properties conf) throws IOException {
+        return lfs.getModifiedTime(mergeDefaults("LocalJDBCTap#getModifiedTime", conf, defaults));
+    }
+
+    private static JobConf mergeDefaults(String methodName, Properties properties, JobConf defaults) {
+        LOG.fine(methodName + " is merging defaults with: " + properties);
+        return HadoopUtil.createJobConf(properties, defaults);
+    }
+
+    private static Properties overwriteProperties(Properties properties, JobConf jobConf) {
+        for (Map.Entry<String, String> entry : jobConf) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+        return properties;
+    }
+
+    /**
+     * Scheme used only for fields and configuration.
+     */
+    private static class LocalScheme<SourceContext, SinkContext> extends
+            Scheme<Properties, RecordReader, OutputCollector, SourceContext, SinkContext> {
+        private static final long serialVersionUID = 5710119342340369543L;
+
+        private Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme;
+        private JobConf defaults;
+        private Tap lfs;
+
+        public LocalScheme(Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme) {
+            super(scheme.getSourceFields(), scheme.getSinkFields());
+            this.scheme = scheme;
+        }
+
+        private void setDefaults(JobConf defaults) {
+            this.defaults = defaults;
+        }
+
+        private void setTap(Tap lfs) {
+            this.lfs = lfs;
+        }
+
+        @Override
+        public void sourceConfInit(FlowProcess<Properties> flowProcess,
+                Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
+            JobConf jobConf = mergeDefaults("LocalScheme#sourceConfInit", conf, defaults);
+            scheme.sourceConfInit(new HadoopFlowProcess(jobConf), lfs, jobConf);
+            overwriteProperties(conf, jobConf);
+        }
+
+        @Override
+        public void sinkConfInit(FlowProcess<Properties> flowProcess,
+                Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
+            JobConf jobConf = mergeDefaults("LocalScheme#sinkConfInit", conf, defaults);
+            scheme.sinkConfInit(new HadoopFlowProcess(jobConf), lfs, jobConf);
+            overwriteProperties(conf, jobConf);
+        }
+
+        @Override
+        public boolean source(FlowProcess<Properties> flowProcess, SourceCall<SourceContext, RecordReader> sourceCall)
+                throws IOException {
+            throw new RuntimeException("LocalJDBCTap#source is never called");
+        }
+
+        @Override
+        public void sink(FlowProcess<Properties> flowProcess, SinkCall<SinkContext, OutputCollector> sinkCall)
+                throws IOException {
+            throw new RuntimeException("LocalJDBCTap#sink is never called");
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (!(object instanceof LocalJDBCTap))
+            return false;
+        if (!super.equals(object))
+            return false;
+
+        LocalJDBCTap localTap = (LocalJDBCTap) object;
+
+        if (path != null ? !path.equals(localTap.path) : localTap.path != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        return result;
+    }
+
+    /** @see Object#toString() */
+    @Override
+    public String toString() {
+        if (path != null)
+            return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[\"" + Util.sanitizeUrl(path) + "\"]";
+        else
+            return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[not initialized]";
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -184,6 +184,9 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
           if ( scheme != null ) {
               scheme.setSinkFields( sinkFields );
               super.setSinkFields( getSinkFields() );
+              if ( getSourceFields().isAll() || getSourceFields().isUnknown() ) {
+                  setSourceFields( sinkFields );
+              }
           } else {
               super.setSinkFields( sinkFields );
           }

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -17,6 +17,7 @@ import cascading.scheme.SinkCall;
 import cascading.scheme.SourceCall;
 import cascading.tap.SinkMode;
 import cascading.tap.Tap;
+import cascading.tuple.Fields;
 import cascading.tuple.TupleEntryCollector;
 import cascading.tuple.TupleEntryIterator;
 import cascading.util.Util;
@@ -167,6 +168,44 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
         public void sink(FlowProcess<Properties> flowProcess, SinkCall<SinkContext, OutputCollector> sinkCall)
                 throws IOException {
             throw new RuntimeException("LocalJDBCTap#sink is never called");
+        }
+
+        @Override
+        public Fields getSinkFields() {
+            if ( scheme != null ) {
+                return scheme.getSinkFields();
+            } else {
+                return super.getSinkFields();
+            }
+        }
+
+        @Override
+        public void setSinkFields( Fields sinkFields ) {
+          if ( scheme != null ) {
+              scheme.setSinkFields( sinkFields );
+              super.setSinkFields( getSinkFields() );
+          } else {
+              super.setSinkFields( sinkFields );
+          }
+        }
+
+        @Override
+        public Fields getSourceFields() {
+            if ( scheme != null ) {
+                return scheme.getSourceFields();
+            } else {
+                return super.getSourceFields();
+            }
+        }
+
+        @Override
+        public void setSourceFields( Fields sourceFields ) {
+            if ( scheme != null ) {
+                scheme.setSourceFields( sourceFields );
+                super.setSourceFields( getSourceFields() );
+            } else {
+                super.setSourceFields( sourceFields );
+            }
         }
     }
 

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -9,8 +9,6 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
 
-import com.twitter.maple.jdbc.JDBCTap;
-
 import cascading.flow.FlowProcess;
 import cascading.flow.hadoop.HadoopFlowProcess;
 import cascading.flow.hadoop.util.HadoopUtil;

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -189,6 +189,16 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
           }
         }
 
+        public Fields retrieveSourceFields( FlowProcess<Properties> flowProcess, Tap tap )
+        {
+          return scheme.retrieveSourceFields( (FlowProcess) flowProcess, tap );
+        }
+
+        public void presentSourceFields( FlowProcess<Properties> flowProcess, Tap tap, Fields fields )
+        {
+          scheme.presentSourceFields( (FlowProcess) flowProcess, tap, fields );
+        }
+
         @Override
         public Fields getSourceFields() {
             if ( scheme != null ) {

--- a/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
+++ b/src/jvm/com/twitter/maple/jdbc/LocalJDBCTap.java
@@ -45,13 +45,13 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
     private static Logger LOG = Logger.getLogger(LocalJDBCTap.class.getName());
 
     private JobConf defaults;
-    private JDBCTap lfs;
+    private JDBCTap tap;
     private final String path;
 
     public LocalJDBCTap(Scheme scheme,
             SinkMode sinkMode, JDBCTap tap, String path) {
         super(new LocalScheme<SourceCtx, SinkCtx>(scheme), sinkMode);
-        this.lfs = tap;
+        this.tap = tap;
         this.path = path;
         setup();
     }
@@ -70,7 +70,7 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
 
         ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setDefaults(defaults);
 
-        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setTap(lfs);
+        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setTap(tap);
     }
 
     @Override
@@ -81,34 +81,34 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
     @Override
     public TupleEntryIterator openForRead(FlowProcess<Properties> flowProcess, RecordReader input) throws IOException {
         JobConf jobConf = mergeDefaults("LocalJDBCTap#openForRead", flowProcess.getConfigCopy(), defaults);
-        return lfs.openForRead(new HadoopFlowProcess(jobConf));
+        return tap.openForRead(new HadoopFlowProcess(jobConf));
     }
 
     @Override
     public TupleEntryCollector openForWrite(FlowProcess<Properties> flowProcess, OutputCollector output)
             throws IOException {
         JobConf jobConf = mergeDefaults("LocalJDBCTap#openForWrite", flowProcess.getConfigCopy(), defaults);
-        return lfs.openForWrite(new HadoopFlowProcess(jobConf));
+        return tap.openForWrite(new HadoopFlowProcess(jobConf));
     }
 
     @Override
     public boolean createResource(Properties conf) throws IOException {
-        return lfs.createResource(mergeDefaults("LocalJDBCTap#createResource", conf, defaults));
+        return tap.createResource(mergeDefaults("LocalJDBCTap#createResource", conf, defaults));
     }
 
     @Override
     public boolean deleteResource(Properties conf) throws IOException {
-        return lfs.deleteResource(mergeDefaults("LocalJDBCTap#deleteResource", conf, defaults));
+        return tap.deleteResource(mergeDefaults("LocalJDBCTap#deleteResource", conf, defaults));
     }
 
     @Override
     public boolean resourceExists(Properties conf) throws IOException {
-        return lfs.resourceExists(mergeDefaults("LocalJDBCTap#resourceExists", conf, defaults));
+        return tap.resourceExists(mergeDefaults("LocalJDBCTap#resourceExists", conf, defaults));
     }
 
     @Override
     public long getModifiedTime(Properties conf) throws IOException {
-        return lfs.getModifiedTime(mergeDefaults("LocalJDBCTap#getModifiedTime", conf, defaults));
+        return tap.getModifiedTime(mergeDefaults("LocalJDBCTap#getModifiedTime", conf, defaults));
     }
 
     private static JobConf mergeDefaults(String methodName, Properties properties, JobConf defaults) {
@@ -132,7 +132,7 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
 
         private Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme;
         private JobConf defaults;
-        private Tap lfs;
+        private Tap tap;
 
         public LocalScheme(Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme) {
             super(scheme.getSourceFields(), scheme.getSinkFields());
@@ -143,15 +143,15 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
             this.defaults = defaults;
         }
 
-        private void setTap(Tap lfs) {
-            this.lfs = lfs;
+        private void setTap(Tap tap) {
+            this.tap = tap;
         }
 
         @Override
         public void sourceConfInit(FlowProcess<Properties> flowProcess,
                 Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
             JobConf jobConf = mergeDefaults("LocalScheme#sourceConfInit", conf, defaults);
-            scheme.sourceConfInit(new HadoopFlowProcess(jobConf), lfs, jobConf);
+            scheme.sourceConfInit(new HadoopFlowProcess(jobConf), this.tap, jobConf);
             overwriteProperties(conf, jobConf);
         }
 
@@ -159,7 +159,7 @@ public class LocalJDBCTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordRead
         public void sinkConfInit(FlowProcess<Properties> flowProcess,
                 Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
             JobConf jobConf = mergeDefaults("LocalScheme#sinkConfInit", conf, defaults);
-            scheme.sinkConfInit(new HadoopFlowProcess(jobConf), lfs, jobConf);
+            scheme.sinkConfInit(new HadoopFlowProcess(jobConf), this.tap, jobConf);
             overwriteProperties(conf, jobConf);
         }
 

--- a/src/jvm/com/twitter/maple/jdbc/TableDesc.java
+++ b/src/jvm/com/twitter/maple/jdbc/TableDesc.java
@@ -27,6 +27,8 @@ import java.util.List;
  * @see JDBCScheme
  */
 public class TableDesc implements Serializable {
+    private static final long serialVersionUID = 2526946099774572740L;
+
     /** Field tableName */
     protected final String tableName;
     /** Field columnNames */

--- a/src/jvm/com/twitter/maple/jdbc/TableDesc.java
+++ b/src/jvm/com/twitter/maple/jdbc/TableDesc.java
@@ -28,13 +28,13 @@ import java.util.List;
  */
 public class TableDesc implements Serializable {
     /** Field tableName */
-    String tableName;
+    protected final String tableName;
     /** Field columnNames */
-    String[] columnNames;
+    protected String[] columnNames;
     /** Field columnDefs */
-    String[] columnDefs;
+    protected String[] columnDefs;
     /** Field primaryKeys */
-    String[] primaryKeys;
+    protected String[] primaryKeys;
 
     /**
      * Constructor TableDesc creates a new TableDesc instance.

--- a/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
+++ b/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
@@ -38,9 +38,10 @@ public class TupleRecord implements DBWritable {
     }
 
     public void write( PreparedStatement statement ) throws SQLException {
-        for( int i = 0, sz = tuple.size(); i < sz; i++ )
+        int statementParameterCount = statement.getParameterMetaData().getParameterCount();
+        for( int i = 0, sz = Math.min( tuple.size(), statementParameterCount ); i < sz; i++ )
             statement.setObject( i + 1, tuple.get( i ) );
-        for ( int i = tuple.size(), sz = statement.getParameterMetaData().getParameterCount(); i < sz; ++ i ) {
+        for ( int i = tuple.size(), sz = statementParameterCount; i < sz; ++ i ) {
             statement.setObject( i + 1, null );
         }
     }

--- a/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
+++ b/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
@@ -38,8 +38,11 @@ public class TupleRecord implements DBWritable {
     }
 
     public void write( PreparedStatement statement ) throws SQLException {
-        for( int i = 0; i < tuple.size(); i++ )
+        for( int i = 0, sz = tuple.size(); i < sz; i++ )
             statement.setObject( i + 1, tuple.get( i ) );
+        for ( int i = tuple.size(), sz = statement.getParameterMetaData().getParameterCount(); i < sz; ++ i ) {
+            statement.setObject( i + 1, null );
+        }
     }
 
     public void readFields( ResultSet resultSet ) throws SQLException {

--- a/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
+++ b/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
@@ -40,7 +40,7 @@ public class TupleRecord implements DBWritable {
     public void write( PreparedStatement statement ) throws SQLException {
         int statementParameterCount = statement.getParameterMetaData().getParameterCount();
         for( int i = 0, sz = Math.min( tuple.size(), statementParameterCount ); i < sz; i++ )
-            statement.setObject( i + 1, tuple.get( i ) );
+            statement.setObject( i + 1, tuple.getObject( i ) );
         for ( int i = tuple.size(), sz = statementParameterCount; i < sz; ++ i ) {
             statement.setObject( i + 1, null );
         }
@@ -50,7 +50,7 @@ public class TupleRecord implements DBWritable {
         tuple = new Tuple();
 
         for( int i = 0; i < resultSet.getMetaData().getColumnCount(); i++ )
-            tuple.add( (Comparable) resultSet.getObject( i + 1 ) );
+            tuple.add( resultSet.getObject( i + 1 ) );
     }
 
 }

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -132,9 +132,9 @@ public class DBConfiguration {
         configureDB(job, driverClass, dbUrl, null, null);
     }
 
-    private Configuration job;
+    protected Configuration job;
 
-    DBConfiguration(Configuration job) {
+    public DBConfiguration(Configuration job) {
         this.job = job;
     }
 
@@ -144,7 +144,7 @@ public class DBConfiguration {
      * @throws ClassNotFoundException
      * @throws SQLException
      */
-    Connection getConnection() throws IOException {
+    public Connection getConnection() throws IOException {
         try {
             Class.forName(job.get(DBConfiguration.DRIVER_CLASS_PROPERTY));
         } catch (ClassNotFoundException exception) {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -99,11 +99,14 @@ public class DBInputFormat<T extends DBWritable>
             if (dbConf.getInputQuery() == null) {
                 query.append("SELECT ");
 
-                for (int i = 0; i < fieldNames.length; i++) {
+                for (int i = 0, sz = fieldNames == null ? 0 : fieldNames.length; i < sz; i++) {
                     query.append(fieldNames[i]);
 
                     if (i != fieldNames.length - 1)
                         query.append(", ");
+                }
+                if ( fieldNames == null ) {
+                    query.append("*");
                 }
 
                 query.append(" FROM ").append(tableName);

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -322,7 +322,7 @@ public class DBInputFormat<T extends DBWritable>
     }
 
     /** {@inheritDoc} */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public RecordReader<LongWritable, T> getRecordReader(InputSplit split, JobConf job,
         Reporter reporter) throws IOException {
         Class inputClass = dbConf.getInputClass();

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -283,7 +283,7 @@ public class DBInputFormat<T extends DBWritable>
 
     /** {@inheritDoc} */
     public void configure(JobConf job) {
-        dbConf = new DBConfiguration(job);
+        dbConf = createDBConfiguration(job);
 
         tableName = dbConf.getInputTableName();
         fieldNames = dbConf.getInputFieldNames();
@@ -298,6 +298,14 @@ public class DBInputFormat<T extends DBWritable>
         }
 
         configureConnection(connection);
+    }
+
+    /**
+     * Creates a new Database Configuration for the job, allowing you to override things like the
+     * connection pooling.
+     */
+    public DBConfiguration createDBConfiguration( JobConf job ) {
+        return new DBConfiguration(job );
     }
 
     protected void configureConnection(Connection connection) {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -287,7 +287,7 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
     /** {@inheritDoc} */
     public RecordWriter<K, V> getRecordWriter(FileSystem filesystem, JobConf job, String name,
         Progressable progress) throws IOException {
-        DBConfiguration dbConf = new DBConfiguration(job);
+        DBConfiguration dbConf = createDBConfiguration(job);
 
         String tableName = dbConf.getOutputTableName();
         String[] fieldNames = dbConf.getOutputFieldNames();
@@ -327,6 +327,14 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
           LOG.info("Executing update statement:\n " + sqlUpdate);
         }
         return new DBRecordWriter(connection, insertPreparedStatement, updatePreparedStatement, batchStatements);
+    }
+
+    /**
+     * Creates a new Database Configuration for the job, allowing you to override things like the
+     * connection pooling.
+     */
+    public DBConfiguration createDBConfiguration( JobConf job ) {
+        return new DBConfiguration(job );
     }
 
     protected void configureConnection(Connection connection) {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -352,6 +352,7 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
      * @param batchSize
      * @param replaceOnInsert     Boolean which says whether inserts should replace.
      */
+    @SuppressWarnings("rawtypes")
     public static void setOutput(
         JobConf job,
         Class<? extends DBOutputFormat> dbOutputFormatClass,

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -228,7 +228,7 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
             if (i != fieldNames.length - 1) { query.append(","); }
         }
 
-        query.append(");");
+        query.append(")");
 
         return query.toString();
     }
@@ -272,8 +272,6 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
                 if (i != updateNames.length - 1) { query.append(" and "); }
             }
         }
-
-        query.append(";");
 
         return query.toString();
     }

--- a/src/jvm/com/twitter/maple/tap/LocalMemorySourceTap.java
+++ b/src/jvm/com/twitter/maple/tap/LocalMemorySourceTap.java
@@ -1,0 +1,209 @@
+package com.twitter.maple.tap;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop.HadoopFlowProcess;
+import cascading.flow.hadoop.util.HadoopUtil;
+import cascading.scheme.Scheme;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tuple.TupleEntryCollector;
+import cascading.tuple.TupleEntryIterator;
+import cascading.util.Util;
+
+/**
+ * A shunt around the restrictions on taps that can run under the
+ * LocalFlowProcess. This class delegates to Lfs for all work, yet can run in
+ * Cascading local mode.
+ *
+ * Due to what appears to be a bug in LocalFlowStep#initTaps, schemes are not
+ * allowed to side-effect the properties passed to sourceConfInit and
+ * sinkConfInit. This appears to be a non-issue because local schemes never set
+ * any properties. overwriteProperties can likely be removed, but is kept in
+ * case custom local schemes eventually set properties (in a future release of
+ * Cascading where that's possible).
+ * 
+ * This is effectively a copy of the com.etsy.cascading.tap.local.LocalTap, but
+ * modified for the MemorySourceTap-ish.
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class LocalMemorySourceTap<SourceCtx, SinkCtx> extends Tap<Properties, RecordReader, OutputCollector> {
+    private static final long serialVersionUID = 3480480638297770870L;
+
+    private static Logger LOG = Logger.getLogger(LocalMemorySourceTap.class.getName());
+
+    private JobConf defaults;
+    private MemorySourceTap tap;
+    private final String path;
+
+    public LocalMemorySourceTap(Scheme scheme,
+            SinkMode sinkMode, MemorySourceTap tap, String path) {
+        super(new LocalScheme<SourceCtx, SinkCtx>(scheme), sinkMode);
+        this.tap = tap;
+        this.path = path;
+        setup();
+    }
+
+    private void setup() {
+        /*
+         * LocalMemorySourceTap requires your system Hadoop configuration for defaults to
+         * supply the wrapped Lfs. Make sure you have your serializations and
+         * serialization tokens defined there.
+         */
+        defaults = new JobConf();
+
+        // HACK: c.t.h.TextLine checks this property for .zip files; the check
+        // assumes the list is non-empty, which we mock up, here
+        defaults.set("mapred.input.dir", path);
+
+        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setDefaults(defaults);
+
+        ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setTap(tap);
+    }
+
+    @Override
+    public String getIdentifier() {
+        return path;
+    }
+
+    @Override
+    public TupleEntryIterator openForRead(FlowProcess<Properties> flowProcess, RecordReader input) throws IOException {
+        JobConf jobConf = mergeDefaults("LocalMemorySourceTap#openForRead", flowProcess.getConfigCopy(), defaults);
+        return tap.openForRead(new HadoopFlowProcess(jobConf));
+    }
+
+    @Override
+    public TupleEntryCollector openForWrite(FlowProcess<Properties> flowProcess, OutputCollector output)
+            throws IOException {
+        JobConf jobConf = mergeDefaults("LocalMemorySourceTap#openForWrite", flowProcess.getConfigCopy(), defaults);
+        return tap.openForWrite(new HadoopFlowProcess(jobConf));
+    }
+
+    @Override
+    public boolean createResource(Properties conf) throws IOException {
+        return tap.createResource(mergeDefaults("LocalMemorySourceTap#createResource", conf, defaults));
+    }
+
+    @Override
+    public boolean deleteResource(Properties conf) throws IOException {
+        return tap.deleteResource(mergeDefaults("LocalMemorySourceTap#deleteResource", conf, defaults));
+    }
+
+    @Override
+    public boolean resourceExists(Properties conf) throws IOException {
+        return tap.resourceExists(mergeDefaults("LocalMemorySourceTap#resourceExists", conf, defaults));
+    }
+
+    @Override
+    public long getModifiedTime(Properties conf) throws IOException {
+        return tap.getModifiedTime(mergeDefaults("LocalMemorySourceTap#getModifiedTime", conf, defaults));
+    }
+
+    private static JobConf mergeDefaults(String methodName, Properties properties, JobConf defaults) {
+        LOG.fine(methodName + " is merging defaults with: " + properties);
+        return HadoopUtil.createJobConf(properties, defaults);
+    }
+
+    private static Properties overwriteProperties(Properties properties, JobConf jobConf) {
+        for (Map.Entry<String, String> entry : jobConf) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+        return properties;
+    }
+
+    /**
+     * Scheme used only for fields and configuration.
+     */
+    private static class LocalScheme<SourceContext, SinkContext> extends
+            Scheme<Properties, RecordReader, OutputCollector, SourceContext, SinkContext> {
+        private static final long serialVersionUID = 5710119342340369543L;
+
+        private Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme;
+        private JobConf defaults;
+        private Tap tap;
+
+        public LocalScheme(Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme) {
+            super(scheme.getSourceFields(), scheme.getSinkFields());
+            this.scheme = scheme;
+        }
+
+        private void setDefaults(JobConf defaults) {
+            this.defaults = defaults;
+        }
+
+        private void setTap(Tap tap) {
+            this.tap = tap;
+        }
+
+        @Override
+        public void sourceConfInit(FlowProcess<Properties> flowProcess,
+                Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
+            JobConf jobConf = mergeDefaults("LocalScheme#sourceConfInit", conf, defaults);
+            scheme.sourceConfInit(new HadoopFlowProcess(jobConf), this.tap, jobConf);
+            overwriteProperties(conf, jobConf);
+        }
+
+        @Override
+        public void sinkConfInit(FlowProcess<Properties> flowProcess,
+                Tap<Properties, RecordReader, OutputCollector> tap, Properties conf) {
+            JobConf jobConf = mergeDefaults("LocalScheme#sinkConfInit", conf, defaults);
+            scheme.sinkConfInit(new HadoopFlowProcess(jobConf), this.tap, jobConf);
+            overwriteProperties(conf, jobConf);
+        }
+
+        @Override
+        public boolean source(FlowProcess<Properties> flowProcess, SourceCall<SourceContext, RecordReader> sourceCall)
+                throws IOException {
+            throw new RuntimeException("LocalMemorySourceTap#source is never called");
+        }
+
+        @Override
+        public void sink(FlowProcess<Properties> flowProcess, SinkCall<SinkContext, OutputCollector> sinkCall)
+                throws IOException {
+            throw new RuntimeException("LocalMemorySourceTap#sink is never called");
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (!(object instanceof LocalMemorySourceTap))
+            return false;
+        if (!super.equals(object))
+            return false;
+
+        LocalMemorySourceTap localTap = (LocalMemorySourceTap) object;
+
+        if (path != null ? !path.equals(localTap.path) : localTap.path != null)
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        return result;
+    }
+
+    /** @see Object#toString() */
+    @Override
+    public String toString() {
+        if (path != null)
+            return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[\"" + Util.sanitizeUrl(path) + "\"]";
+        else
+            return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[not initialized]";
+    }
+}

--- a/src/jvm/com/twitter/maple/tap/LocalMemorySourceTap.java
+++ b/src/jvm/com/twitter/maple/tap/LocalMemorySourceTap.java
@@ -64,7 +64,10 @@ public class LocalMemorySourceTap<SourceCtx, SinkCtx> extends Tap<Properties, Re
 
         // HACK: c.t.h.TextLine checks this property for .zip files; the check
         // assumes the list is non-empty, which we mock up, here
-        defaults.set("mapred.input.dir", path);
+        defaults.setStrings( "io.serializations", new String[] {
+            "org.apache.hadoop.io.serializer.WritableSerialization",
+            "cascading.tuple.hadoop.TupleSerialization"
+        } );
 
         ((LocalScheme<SourceCtx, SinkCtx>) this.getScheme()).setDefaults(defaults);
 

--- a/src/jvm/com/twitter/maple/tap/LocalTapAdapter.java
+++ b/src/jvm/com/twitter/maple/tap/LocalTapAdapter.java
@@ -25,6 +25,7 @@ import cascading.util.Util;
 /**
  * This class is intended to wrap a Hadoop-based Tap to be a Local-tap.
  */
+@SuppressWarnings("rawtypes")
 public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends Tap<Properties, RecordReader, OutputCollector> {
   private static final long serialVersionUID = 8552212538252771309L;
 
@@ -45,6 +46,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
    * @param path Path for this tap
    * @param config Default configuration required for the tap.
    */
+  @SuppressWarnings("unchecked")
   public LocalTapAdapter( Scheme scheme, SinkMode sinkMode, HADOOP_TAP tap, String path, JobConf config ) {
     super( new LocalScheme<SourceCtx, SinkCtx>( scheme ), sinkMode );
     this.tap = tap;
@@ -53,6 +55,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
   }
 
 
+  @SuppressWarnings("unchecked")
   private void setup( JobConf config ) {
     /*
      * LocalTapAdapter requires your system Hadoop configuration for
@@ -77,6 +80,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public TupleEntryIterator openForRead( FlowProcess<Properties> flowProcess, RecordReader input ) throws IOException {
     JobConf jobConf = mergeDefaults( "LocalTapAdapter#openForRead", flowProcess.getConfigCopy(), defaults );
@@ -84,6 +88,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public TupleEntryCollector openForWrite( FlowProcess<Properties> flowProcess, OutputCollector output ) throws IOException {
     JobConf jobConf = mergeDefaults( "LocalTapAdapter#openForWrite", flowProcess.getConfigCopy(), defaults );
@@ -91,24 +96,28 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public boolean createResource( Properties conf ) throws IOException {
     return tap.createResource( mergeDefaults( "LocalTapAdapter#createResource", conf, defaults ) );
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public boolean deleteResource( Properties conf ) throws IOException {
     return tap.deleteResource( mergeDefaults( "LocalTapAdapter#deleteResource", conf, defaults ) );
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public boolean resourceExists( Properties conf ) throws IOException {
     return tap.resourceExists( mergeDefaults( "LocalTapAdapter#resourceExists", conf, defaults ) );
   }
 
 
+  @SuppressWarnings("unchecked")
   @Override
   public long getModifiedTime( Properties conf ) throws IOException {
     return tap.getModifiedTime( mergeDefaults( "LocalTapAdapter#getModifiedTime", conf, defaults ) );
@@ -169,6 +178,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
     }
 
 
+    @SuppressWarnings("unchecked")
     @Override
     public void sourceConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, RecordReader, OutputCollector> tap, Properties conf ) {
       JobConf jobConf = mergeDefaults( "LocalScheme#sourceConfInit", conf, defaults );
@@ -177,6 +187,7 @@ public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends
     }
 
 
+    @SuppressWarnings("unchecked")
     @Override
     public void sinkConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, RecordReader, OutputCollector> tap, Properties conf ) {
       JobConf jobConf = mergeDefaults( "LocalScheme#sinkConfInit", conf, defaults );

--- a/src/jvm/com/twitter/maple/tap/LocalTapAdapter.java
+++ b/src/jvm/com/twitter/maple/tap/LocalTapAdapter.java
@@ -1,0 +1,261 @@
+package com.twitter.maple.tap;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputCollector;
+import org.apache.hadoop.mapred.RecordReader;
+
+import cascading.flow.FlowProcess;
+import cascading.flow.hadoop.HadoopFlowProcess;
+import cascading.flow.hadoop.util.HadoopUtil;
+import cascading.scheme.Scheme;
+import cascading.scheme.SinkCall;
+import cascading.scheme.SourceCall;
+import cascading.tap.SinkMode;
+import cascading.tap.Tap;
+import cascading.tuple.Fields;
+import cascading.tuple.TupleEntryCollector;
+import cascading.tuple.TupleEntryIterator;
+import cascading.util.Util;
+
+/**
+ * This class is intended to wrap a Hadoop-based Tap to be a Local-tap.
+ */
+public class LocalTapAdapter<HADOOP_TAP extends Tap, SourceCtx, SinkCtx> extends Tap<Properties, RecordReader, OutputCollector> {
+  private static final long serialVersionUID = 8552212538252771309L;
+
+  private static Logger LOG = Logger.getLogger( LocalTapAdapter.class.getName() );
+
+  private JobConf defaults;
+
+  private HADOOP_TAP tap;
+
+  private final String path;
+
+
+  /**
+   * 
+   * @param scheme Scheme to wrap.
+   * @param sinkMode Sink Mode to use
+   * @param tap Tap to wrap
+   * @param path Path for this tap
+   * @param config Default configuration required for the tap.
+   */
+  public LocalTapAdapter( Scheme scheme, SinkMode sinkMode, HADOOP_TAP tap, String path, JobConf config ) {
+    super( new LocalScheme<SourceCtx, SinkCtx>( scheme ), sinkMode );
+    this.tap = tap;
+    this.path = path;
+    setup( config );
+  }
+
+
+  private void setup( JobConf config ) {
+    /*
+     * LocalTapAdapter requires your system Hadoop configuration for
+     * defaults to supply the wrapped tap. Make sure you have your
+     * serializations and serialization tokens defined there.
+     */
+    defaults = new JobConf( config );
+
+    // HACK: c.t.h.TextLine checks this property for .zip files; the check
+    // assumes the list is non-empty, which we mock up, here
+    defaults.setStrings( "io.serializations", new String[] { "org.apache.hadoop.io.serializer.WritableSerialization", "cascading.tuple.hadoop.TupleSerialization" } );
+
+    ( (LocalScheme<SourceCtx, SinkCtx>) this.getScheme() ).setDefaults( defaults );
+
+    ( (LocalScheme<SourceCtx, SinkCtx>) this.getScheme() ).setTap( tap );
+  }
+
+
+  @Override
+  public String getIdentifier() {
+    return path;
+  }
+
+
+  @Override
+  public TupleEntryIterator openForRead( FlowProcess<Properties> flowProcess, RecordReader input ) throws IOException {
+    JobConf jobConf = mergeDefaults( "LocalTapAdapter#openForRead", flowProcess.getConfigCopy(), defaults );
+    return tap.openForRead( new HadoopFlowProcess( jobConf ) );
+  }
+
+
+  @Override
+  public TupleEntryCollector openForWrite( FlowProcess<Properties> flowProcess, OutputCollector output ) throws IOException {
+    JobConf jobConf = mergeDefaults( "LocalTapAdapter#openForWrite", flowProcess.getConfigCopy(), defaults );
+    return tap.openForWrite( new HadoopFlowProcess( jobConf ) );
+  }
+
+
+  @Override
+  public boolean createResource( Properties conf ) throws IOException {
+    return tap.createResource( mergeDefaults( "LocalTapAdapter#createResource", conf, defaults ) );
+  }
+
+
+  @Override
+  public boolean deleteResource( Properties conf ) throws IOException {
+    return tap.deleteResource( mergeDefaults( "LocalTapAdapter#deleteResource", conf, defaults ) );
+  }
+
+
+  @Override
+  public boolean resourceExists( Properties conf ) throws IOException {
+    return tap.resourceExists( mergeDefaults( "LocalTapAdapter#resourceExists", conf, defaults ) );
+  }
+
+
+  @Override
+  public long getModifiedTime( Properties conf ) throws IOException {
+    return tap.getModifiedTime( mergeDefaults( "LocalTapAdapter#getModifiedTime", conf, defaults ) );
+  }
+
+
+  private static JobConf mergeDefaults( String methodName, Properties properties, JobConf defaults ) {
+    LOG.fine( methodName + " is merging defaults with: " + properties );
+    return HadoopUtil.createJobConf( properties, defaults );
+  }
+
+
+  private static Properties overwriteProperties( Properties properties, JobConf jobConf ) {
+    for ( Map.Entry<String, String> entry : jobConf ) {
+      properties.setProperty( entry.getKey(), entry.getValue() );
+    }
+    return properties;
+  }
+
+  /**
+   * Scheme used only for fields and configuration.
+   */
+  private static class LocalScheme<SourceContext, SinkContext> extends Scheme<Properties, RecordReader, OutputCollector, SourceContext, SinkContext> {
+    private static final long serialVersionUID = 5710119342340369543L;
+
+    private Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme;
+
+    private JobConf defaults;
+
+    private Tap tap;
+
+
+    public LocalScheme( Scheme<JobConf, RecordReader, OutputCollector, SourceContext, SinkContext> scheme ) {
+      super( scheme.getSourceFields(), scheme.getSinkFields() );
+      this.scheme = scheme;
+    }
+
+
+    private void setDefaults( JobConf defaults ) {
+      this.defaults = defaults;
+    }
+
+
+    private void setTap( Tap tap ) {
+      this.tap = tap;
+    }
+
+
+    @Override
+    public Fields retrieveSourceFields( FlowProcess<Properties> flowProcess, Tap tap ) {
+      return scheme.retrieveSourceFields( new HadoopFlowProcess( defaults ), this.tap );
+    }
+
+
+    @Override
+    public void presentSourceFields( FlowProcess<Properties> flowProcess, Tap tap, Fields fields ) {
+      scheme.presentSourceFields( new HadoopFlowProcess( defaults ), this.tap, fields );
+    }
+
+
+    @Override
+    public void sourceConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, RecordReader, OutputCollector> tap, Properties conf ) {
+      JobConf jobConf = mergeDefaults( "LocalScheme#sourceConfInit", conf, defaults );
+      scheme.sourceConfInit( new HadoopFlowProcess( jobConf ), this.tap, jobConf );
+      overwriteProperties( conf, jobConf );
+    }
+
+
+    @Override
+    public void sinkConfInit( FlowProcess<Properties> flowProcess, Tap<Properties, RecordReader, OutputCollector> tap, Properties conf ) {
+      JobConf jobConf = mergeDefaults( "LocalScheme#sinkConfInit", conf, defaults );
+      scheme.sinkConfInit( new HadoopFlowProcess( jobConf ), this.tap, jobConf );
+      overwriteProperties( conf, jobConf );
+    }
+
+
+    @Override
+    public Fields retrieveSinkFields( FlowProcess<Properties> flowProcess, Tap tap ) {
+      return scheme.retrieveSinkFields( new HadoopFlowProcess( defaults ), this.tap );
+    }
+
+
+    @Override
+    public void presentSinkFields( FlowProcess<Properties> flowProcess, Tap tap, Fields fields ) {
+      scheme.presentSinkFields( new HadoopFlowProcess( defaults ), this.tap, fields );
+    }
+
+
+    @Override
+    public boolean source( FlowProcess<Properties> flowProcess, SourceCall<SourceContext, RecordReader> sourceCall ) throws IOException {
+      throw new RuntimeException( "LocalTapAdapter#source is never called" );
+    }
+
+
+    @Override
+    public void sink( FlowProcess<Properties> flowProcess, SinkCall<SinkContext, OutputCollector> sinkCall ) throws IOException {
+      throw new RuntimeException( "LocalTapAdapter#sink is never called" );
+    }
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ( ( defaults == null ) ? 0 : defaults.hashCode() );
+    result = prime * result + ( ( path == null ) ? 0 : path.hashCode() );
+    result = prime * result + ( ( tap == null ) ? 0 : tap.hashCode() );
+    return result;
+  }
+
+
+  @Override
+  public boolean equals( Object obj ) {
+    if ( this == obj )
+      return true;
+    if ( !super.equals( obj ) )
+      return false;
+    if ( getClass() != obj.getClass() )
+      return false;
+    LocalTapAdapter other = (LocalTapAdapter) obj;
+    if ( defaults == null ) {
+      if ( other.defaults != null )
+        return false;
+    } else if ( !defaults.equals( other.defaults ) )
+      return false;
+    if ( path == null ) {
+      if ( other.path != null )
+        return false;
+    } else if ( !path.equals( other.path ) )
+      return false;
+    if ( tap == null ) {
+      if ( other.tap != null )
+        return false;
+    } else if ( !tap.equals( other.tap ) )
+      return false;
+    return true;
+  }
+
+
+  /** @see Object#toString() */
+  @Override
+  public String toString() {
+    if ( path != null ) {
+      return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[\"" + Util.sanitizeUrl( path ) + "\"]";
+    } else {
+      return getClass().getSimpleName() + "[\"" + getScheme() + "\"]" + "[not initialized]";
+    }
+  }
+}

--- a/src/jvm/com/twitter/maple/tap/MemorySinkTap.java
+++ b/src/jvm/com/twitter/maple/tap/MemorySinkTap.java
@@ -14,13 +14,13 @@ import java.io.IOException;
 import java.util.List;
 
 public class MemorySinkTap extends Lfs {
+    private static final long serialVersionUID = 2341505558519666493L;
+
     private List<Tuple> results;
-    private Fields fields;
 
     public MemorySinkTap(List<Tuple> tuples, Fields fields) {
         super(new SequenceFile(Fields.ALL), getTempDir());
         this.results = tuples;
-        this.fields = fields;
     }
 
     public MemorySinkTap(List<Tuple> tuples) {
@@ -52,7 +52,6 @@ public class MemorySinkTap extends Lfs {
             results.add(tuple.getTupleCopy());
 
             if (first_time) {
-                fields = tuple.getFields();
                 first_time = false;
             }
         }

--- a/src/jvm/com/twitter/maple/tap/MemorySourceTap.java
+++ b/src/jvm/com/twitter/maple/tap/MemorySourceTap.java
@@ -23,9 +23,12 @@ import java.util.UUID;
 
 public class MemorySourceTap extends SourceTap<JobConf, RecordReader<TupleWrapper, NullWritable>>
     implements Serializable {
+    private static final long serialVersionUID = -3883105721794069739L;
 
     public static class MemorySourceScheme
         extends Scheme<JobConf, RecordReader<TupleWrapper, NullWritable>, Void, Object[], Void> {
+
+        private static final long serialVersionUID = 919689539720607932L;
 
         private transient List<Tuple> tuples;
         private final String id;

--- a/src/jvm/com/twitter/maple/tap/StdoutTap.java
+++ b/src/jvm/com/twitter/maple/tap/StdoutTap.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class StdoutTap extends Lfs {
+    private static final long serialVersionUID = -1059663889045644321L;
 
     public StdoutTap() {
         super(new SequenceFile(Fields.ALL), getTempDir());


### PR DESCRIPTION
There are only two places in the DBXxxFormats which use a trailing semicolor and Derby is freaking out about them. This change removes them from the query entirely and it works fine on both Derby and MySQL.
