### PR TITLE
Make JDBCScheme table alias optional to allow usage on Vertica database 

### DIFF
--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -74,7 +74,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy )
     {
-        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy, true );
+        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy );
     }
 
     /**

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -59,6 +59,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     private String selectQuery;
     private String countQuery;
     private long limit = -1;
+    private Boolean aliasTable = true;
 
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.
@@ -73,7 +74,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy )
     {
-        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy );
+        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy, true );
     }
 
     /**
@@ -88,8 +89,9 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      * @param limit             of type long
      * @param updateByFields    of type Fields
      * @param updateBy          of type String[]
+     * @param aliasTable        of type Boolean
      */
-    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy )
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy, Boolean aliasTable)
     {
         this.columnFields = columnFields;
 
@@ -117,9 +119,29 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         this.orderBy = orderBy;
         this.conditions = conditions;
         this.limit = limit;
+        this.aliasTable = aliasTable;
 
         this.inputFormatClass = inputFormatClass;
         this.outputFormatClass = outputFormatClass;
+    }
+
+    /**
+     * Constructor JDBCScheme creates a new JDBCScheme instance.
+     *
+     * @param inputFormatClass  of type Class<? extends DBInputFormat>
+     * @param outputFormatClass of type Class<? extends DBOutputFormat>
+     * @param columnFields      of type Fields
+     * @param columns           of type String[]
+     * @param orderBy           of type String[]
+     * @param conditions        of type String
+     * @param limit             of type long
+     * @param updateByFields    of type Fields
+     * @param updateBy          of type String[]
+     */
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy)
+    {
+        this(inputFormatClass, outputFormatClass, columnFields, columns, orderBy, conditions, limit, updateByFields, updateBy, true )
+
     }
 
     private void verifyColumns( Fields columnFields, String[] columns )
@@ -405,7 +427,35 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, String[] columns, String selectQuery, String countQuery, long limit )
     {
-        this( inputFormatClass, new Fields( columns ), columns, selectQuery, countQuery, limit );
+        this( inputFormatClass, new Fields( columns ), columns, selectQuery, countQuery, limit, true );
+    }
+
+    /**
+     * Constructor JDBCScheme creates a new JDBCScheme instance.
+     *
+     * @param inputFormatClass of type Class<? extends DBInputFormat>
+     * @param columnFields     of type Fields
+     * @param columns          of type String[]
+     * @param selectQuery      of type String
+     * @param countQuery       of type String
+     * @param limit            of type long
+     * @param tableAlias       of type Boolean
+     */
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Fields columnFields, String[] columns, String selectQuery, String countQuery, long limit, Boolean tableAlias )
+    {
+        this.columnFields = columnFields;
+
+        verifyColumns( columnFields, columns );
+
+        setSourceFields( columnFields );
+
+        this.columns = columns;
+        this.selectQuery = selectQuery.trim().replaceAll( ";$", "" );
+        this.countQuery = countQuery.trim().replaceAll( ";$", "" );
+        this.limit = limit;
+        this.tableAlias = tableAlias;
+
+        this.inputFormatClass = inputFormatClass;
     }
 
     /**
@@ -418,20 +468,9 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      * @param countQuery       of type String
      * @param limit            of type long
      */
-    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Fields columnFields, String[] columns, String selectQuery, String countQuery, long limit )
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Fields columnFields, String[] columns, String selectQuery, String countQuery, long limit)
     {
-        this.columnFields = columnFields;
-
-        verifyColumns( columnFields, columns );
-
-        setSourceFields( columnFields );
-
-        this.columns = columns;
-        this.selectQuery = selectQuery.trim().replaceAll( ";$", "" );
-        this.countQuery = countQuery.trim().replaceAll( ";$", "" );
-        this.limit = limit;
-
-        this.inputFormatClass = inputFormatClass;
+        this(inputFormatClass, columnFields, columns, selectQuery, countQuery, limit, true );
     }
 
     /**
@@ -514,11 +553,11 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         int concurrentReads = ( (JDBCTap) tap ).concurrentReads;
 
         if( selectQuery != null )
-            DBInputFormat.setInput( conf, TupleRecord.class, selectQuery, countQuery, limit, concurrentReads );
+            DBInputFormat.setInput( conf, TupleRecord.class, selectQuery, countQuery, limit, concurrentReads, tableAlias );
         else {
             String tableName = ( (JDBCTap) tap ).getTableName();
             String joinedOrderBy = orderBy != null ? Util.join( orderBy, ", " ) : null;
-            DBInputFormat.setInput( conf, TupleRecord.class, tableName, conditions, joinedOrderBy, limit, concurrentReads, columns );
+            DBInputFormat.setInput( conf, TupleRecord.class, tableName, conditions, joinedOrderBy, limit, concurrentReads, columns, tableAlias );
         }
 
         if( inputFormatClass != null )

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -74,7 +74,8 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy )
     {
-        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy );
+        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit,
+            updateBy != null ? new Fields( updateBy ) : null, updateBy );
     }
 
     /**
@@ -91,7 +92,8 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy, Boolean tableAlias )
     {
-        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy, tableAlias );
+        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit,
+            updateBy != null ? new Fields( updateBy ) : null, updateBy, tableAlias );
     }
 
     /**

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -75,7 +75,8 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy )
     {
         this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit,
-            updateBy != null ? new Fields( updateBy ) : null, updateBy );
+            updateBy != null ? new Fields( updateBy ) : null,
+            updateBy );
     }
 
     /**
@@ -93,7 +94,8 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy, Boolean tableAlias )
     {
         this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit,
-            updateBy != null ? new Fields( updateBy ) : null, updateBy, tableAlias );
+            updateBy != null ? new Fields( updateBy ) : null,
+            updateBy, tableAlias );
     }
 
     /**

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -59,7 +59,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     private String selectQuery;
     private String countQuery;
     private long limit = -1;
-    private Boolean aliasTable = true;
+    private Boolean tableAlias = true;
 
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.
@@ -82,6 +82,23 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      *
      * @param inputFormatClass  of type Class<? extends DBInputFormat>
      * @param outputFormatClass of type Class<? extends DBOutputFormat>
+     * @param columns           of type String[]
+     * @param orderBy           of type String[]
+     * @param conditions        of type String
+     * @param limit             of type long
+     * @param updateBy          of type String[]
+     * @param tableAlias        of type Boolean
+     */
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, long limit, String[] updateBy, Boolean tableAlias )
+    {
+        this( inputFormatClass, outputFormatClass, new Fields( columns ), columns, orderBy, conditions, limit, updateBy != null ? new Fields( updateBy ) : null, updateBy, tableAlias );
+    }
+
+    /**
+     * Constructor JDBCScheme creates a new JDBCScheme instance.
+     *
+     * @param inputFormatClass  of type Class<? extends DBInputFormat>
+     * @param outputFormatClass of type Class<? extends DBOutputFormat>
      * @param columnFields      of type Fields
      * @param columns           of type String[]
      * @param orderBy           of type String[]
@@ -89,9 +106,9 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      * @param limit             of type long
      * @param updateByFields    of type Fields
      * @param updateBy          of type String[]
-     * @param aliasTable        of type Boolean
+     * @param tableAlias        of type Boolean
      */
-    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy, Boolean aliasTable)
+    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy, Boolean tableAlias)
     {
         this.columnFields = columnFields;
 
@@ -119,7 +136,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         this.orderBy = orderBy;
         this.conditions = conditions;
         this.limit = limit;
-        this.aliasTable = aliasTable;
+        this.tableAlias = tableAlias;
 
         this.inputFormatClass = inputFormatClass;
         this.outputFormatClass = outputFormatClass;
@@ -140,7 +157,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, Fields columnFields, String[] columns, String[] orderBy, String conditions, long limit, Fields updateByFields, String[] updateBy)
     {
-        this(inputFormatClass, outputFormatClass, columnFields, columns, orderBy, conditions, limit, updateByFields, updateBy, true )
+        this(inputFormatClass, outputFormatClass, columnFields, columns, orderBy, conditions, limit, updateByFields, updateBy, true );
 
     }
 
@@ -331,7 +348,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( String[] columns, String conditions, long limit )
     {
-        this( null, null, columns, null, conditions, limit, null );
+        this( null, null, new Fields( columns ), columns, null, conditions, limit, null, null );
     }
 
     /**
@@ -378,7 +395,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( String[] columns, long limit )
     {
-        this( null, null, columns, null, null, limit, null );
+        this( null, null, new Fields( columns ), columns, null, null, limit, null, null );
     }
 
     /**
@@ -557,7 +574,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
         else {
             String tableName = ( (JDBCTap) tap ).getTableName();
             String joinedOrderBy = orderBy != null ? Util.join( orderBy, ", " ) : null;
-            DBInputFormat.setInput( conf, TupleRecord.class, tableName, conditions, joinedOrderBy, limit, concurrentReads, columns, tableAlias );
+            DBInputFormat.setInput( conf, TupleRecord.class, tableName, conditions, joinedOrderBy, limit, concurrentReads, tableAlias, columns );
         }
 
         if( inputFormatClass != null )

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -80,7 +80,7 @@ public class DBConfiguration {
     /** Class name implementing DBWritable which will hold input tuples */
     public static final String INPUT_CLASS_PROPERTY = "mapred.jdbc.input.class";
 
-    /** ORDER BY clause in the input SELECT statement */
+    /** Boolean to include table name alias in the input SELECT statement */
     public static final String INPUT_TABLE_ALIAS = "mapred.jdbc.input.table.alias";
 
     /** Output table name */

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -80,6 +80,9 @@ public class DBConfiguration {
     /** Class name implementing DBWritable which will hold input tuples */
     public static final String INPUT_CLASS_PROPERTY = "mapred.jdbc.input.class";
 
+    /** ORDER BY clause in the input SELECT statement */
+    public static final String INPUT_TABLE_ALIAS = "mapred.jdbc.input.table.alias";
+
     /** Output table name */
     public static final String OUTPUT_TABLE_NAME_PROPERTY = "mapred.jdbc.output.table.name";
 
@@ -192,6 +195,14 @@ public class DBConfiguration {
         if (orderby != null && orderby.length() > 0) {
             job.set(DBConfiguration.INPUT_ORDER_BY_PROPERTY, orderby);
         }
+    }
+
+    Boolean getTableAlias() {
+        return job.get(DBConfiguration.INPUT_TABLE_ALIAS);
+    }
+
+    void setTableAlias(Boolean alias) {
+        job.set(DBConfiguration.INPUT_TABLE_ALIAS, alias);
     }
 
     String getInputQuery() {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -198,11 +198,11 @@ public class DBConfiguration {
     }
 
     Boolean getTableAlias() {
-        return job.get(DBConfiguration.INPUT_TABLE_ALIAS);
+        return job.getBoolean(DBConfiguration.INPUT_TABLE_ALIAS, true);
     }
 
     void setTableAlias(Boolean alias) {
-        job.set(DBConfiguration.INPUT_TABLE_ALIAS, alias);
+        job.setBoolean(DBConfiguration.INPUT_TABLE_ALIAS, alias);
     }
 
     String getInputQuery() {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -107,7 +107,10 @@ public class DBInputFormat<T extends DBWritable>
                 }
 
                 query.append(" FROM ").append(tableName);
-                query.append(" AS ").append(tableName); //in hsqldb this is necessary
+
+                if (dbConf.getTableAlias()) {
+                    query.append(" AS ").append(tableName); //in hsqldb this is necessary
+                }
 
                 if (conditions != null && conditions.length() > 0)
                     query.append(" WHERE (").append(conditions).append(")");
@@ -405,7 +408,7 @@ public class DBInputFormat<T extends DBWritable>
      */
     public static void setInput(JobConf job, Class<? extends DBWritable> inputClass,
         String tableName, String conditions, String orderBy, long limit, int concurrentReads,
-        String... fieldNames) {
+        String... fieldNames, Boolean tableAlias) {
         job.setInputFormat(DBInputFormat.class);
 
         DBConfiguration dbConf = new DBConfiguration(job);
@@ -415,6 +418,7 @@ public class DBInputFormat<T extends DBWritable>
         dbConf.setInputFieldNames(fieldNames);
         dbConf.setInputConditions(conditions);
         dbConf.setInputOrderBy(orderBy);
+        dbConf.setTableAlias(tableAlias);
 
         if (limit != -1)
             dbConf.setInputLimit(limit);
@@ -435,7 +439,7 @@ public class DBInputFormat<T extends DBWritable>
      * @param concurrentReads
      */
     public static void setInput(JobConf job, Class<? extends DBWritable> inputClass,
-        String selectQuery, String countQuery, long limit, int concurrentReads) {
+        String selectQuery, String countQuery, long limit, int concurrentReads, Boolean tableAlias) {
         job.setInputFormat(DBInputFormat.class);
 
         DBConfiguration dbConf = new DBConfiguration(job);
@@ -443,6 +447,7 @@ public class DBInputFormat<T extends DBWritable>
         dbConf.setInputClass(inputClass);
         dbConf.setInputQuery(selectQuery);
         dbConf.setInputCountQuery(countQuery);
+        dbConf.setTableAlias(tableAlias);
 
         if (limit != -1)
             dbConf.setInputLimit(limit);

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -408,7 +408,7 @@ public class DBInputFormat<T extends DBWritable>
      */
     public static void setInput(JobConf job, Class<? extends DBWritable> inputClass,
         String tableName, String conditions, String orderBy, long limit, int concurrentReads,
-        String... fieldNames, Boolean tableAlias) {
+        Boolean tableAlias, String... fieldNames) {
         job.setInputFormat(DBInputFormat.class);
 
         DBConfiguration dbConf = new DBConfiguration(job);


### PR DESCRIPTION
We at Etsy have started using a Vertica database as a source for big data jobs. Vertica does not allow connections to a particular database/schema. This implies that table names have to be prefixed with the schema name like "schema_name.table_name". This causes JDBCScheme to fail as Vertica, like many other databases, does not like a dot in the table alias. This changeset makes the table alias optional allowing JDBCTap to be used with Vertica.
