### PR TITLE
Removed cast to Comparable when adding database objects to a Tuple.

### DIFF
--- a/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
+++ b/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
@@ -46,7 +46,7 @@ public class TupleRecord implements DBWritable {
         tuple = new Tuple();
 
         for( int i = 0; i < resultSet.getMetaData().getColumnCount(); i++ )
-            tuple.add( (Comparable) resultSet.getObject( i + 1 ) );
+            tuple.add( resultSet.getObject( i + 1 ) );
     }
 
 }


### PR DESCRIPTION
Currently it is not possible to read rows from a PostgreSQL database
that are org.postgresql.util.PGobject instances, since they don't
implement java.lang.Comparable. Removing this type cast fixes this.
