### PR TITLE
Add support for DataDrivenDBInputFormat & Add a JDBCScheme builder. 

### DIFF
--- a/src/jvm/com/twitter/maple/jdbc/db/BigDecimalSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/BigDecimalSplitter.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over BigDecimal values.
+ */
+public class BigDecimalSplitter implements DBSplitter {
+    private static final Log LOG = LogFactory.getLog(BigDecimalSplitter.class);
+
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        BigDecimal minVal = results.getBigDecimal(1);
+        BigDecimal maxVal = results.getBigDecimal(2);
+
+        String lowClausePrefix = colName + " >= ";
+        String highClausePrefix = colName + " < ";
+
+        BigDecimal numSplits = new BigDecimal(conf.getInt(DBConfiguration.CONCURRENT_READS_PROPERTY, 1));
+
+        if (minVal == null && maxVal == null) {
+            // Range is null to null. Return a null split accordingly.
+            List<InputSplit> splits = new ArrayList<InputSplit>();
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        if (minVal == null || maxVal == null) {
+            // Don't know what is a reasonable min/max value for interpolation. Fail.
+            LOG.error("Cannot find a range for NUMERIC or DECIMAL fields with one end NULL.");
+            return null;
+        }
+
+        // Get all the split points together.
+        List<BigDecimal> splitPoints = split(numSplits, minVal, maxVal);
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        // Turn the split points into a set of intervals.
+        BigDecimal start = splitPoints.get(0);
+        for (int i = 1; i < splitPoints.size(); i++) {
+            BigDecimal end = splitPoints.get(i);
+
+            if (i == splitPoints.size() - 1) {
+                // This is the last one; use a closed interval.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + start.toString(),
+                        colName + " <= " + end.toString()));
+            } else {
+                // Normal open-interval case.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + start.toString(),
+                        highClausePrefix + end.toString()));
+            }
+
+            start = end;
+        }
+
+        return splits;
+    }
+
+    private static final BigDecimal MIN_INCREMENT = new BigDecimal(10000 * Double.MIN_VALUE);
+
+    /**
+     * Divide numerator by denominator. If impossible in exact mode, use rounding.
+     */
+    protected BigDecimal tryDivide(BigDecimal numerator, BigDecimal denominator) {
+        try {
+            return numerator.divide(denominator);
+        } catch (ArithmeticException ae) {
+            return numerator.divide(denominator, BigDecimal.ROUND_HALF_UP);
+        }
+    }
+
+    /**
+     * Returns a list of BigDecimals one element longer than the list of input splits.
+     * This represents the boundaries between input splits.
+     * All splits are open on the top end, except the last one.
+     *
+     * So the list [0, 5, 8, 12, 18] would represent splits capturing the intervals:
+     *
+     * [0, 5)
+     * [5, 8)
+     * [8, 12)
+     * [12, 18] note the closed interval for the last split.
+     */
+    List<BigDecimal> split(BigDecimal numSplits, BigDecimal minVal, BigDecimal maxVal)
+            throws SQLException {
+
+        List<BigDecimal> splits = new ArrayList<BigDecimal>();
+
+        // Use numSplits as a hint. May need an extra task if the size doesn't
+        // divide cleanly.
+
+        BigDecimal splitSize = tryDivide(maxVal.subtract(minVal), (numSplits));
+        if (splitSize.compareTo(MIN_INCREMENT) < 0) {
+            splitSize = MIN_INCREMENT;
+            LOG.warn("Set BigDecimal splitSize to MIN_INCREMENT");
+        }
+
+        BigDecimal curVal = minVal;
+
+        while (curVal.compareTo(maxVal) <= 0) {
+            splits.add(curVal);
+            curVal = curVal.add(splitSize);
+        }
+
+        if (splits.get(splits.size() - 1).compareTo(maxVal) != 0 || splits.size() == 1) {
+            // We didn't end on the maxVal. Add that to the end of the list.
+            splits.add(maxVal);
+        }
+
+        return splits;
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/BigDecimalSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/BigDecimalSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/BooleanSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/BooleanSplitter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over boolean values.
+ */
+public class BooleanSplitter implements DBSplitter {
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        if (results.getString(1) == null && results.getString(2) == null) {
+            // Range is null to null. Return a null split accordingly.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        boolean minVal = results.getBoolean(1);
+        boolean maxVal = results.getBoolean(2);
+
+        // Use one or two splits.
+        if (!minVal) {
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " = FALSE", colName + " = FALSE"));
+        }
+
+        if (maxVal) {
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " = TRUE", colName + " = TRUE"));
+        }
+
+        if (results.getString(1) == null || results.getString(2) == null) {
+            // Include a null value.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+        }
+
+        return splits;
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/BooleanSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/BooleanSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBInputFormat.java
@@ -338,7 +338,10 @@ public class DBInputFormat<T extends DBWritable>
         try {
             Statement statement = connection.createStatement();
 
-            ResultSet results = statement.executeQuery(getCountQuery());
+            String countQuery = getCountQuery();
+
+            LOG.info("Getting splits: " + countQuery);
+            ResultSet results = statement.executeQuery(countQuery);
 
             long count = 0;
 

--- a/src/jvm/com/twitter/maple/jdbc/db/DBSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBSplitter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * DBSplitter will generate DBInputSplits to use with DataDrivenDBInputFormat.
+ * DataDrivenDBInputFormat needs to interpolate between two values that
+ * represent the lowest and highest valued records to import. Depending
+ * on the data-type of the column, this requires different behavior.
+ * DBSplitter implementations should perform this for a data type or family
+ * of data types.
+ */
+public interface DBSplitter {
+    /**
+     * Given a ResultSet containing one record (and already advanced to that record)
+     * with two columns (a low value, and a high value, both of the same type), determine
+     * a set of splits that span the given values.
+     */
+    List<InputSplit> split(Configuration conf, ResultSet results, String colName) throws SQLException;
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/DBSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/DataDrivenDBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DataDrivenDBInputFormat.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.*;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A InputFormat that reads input data from an SQL table.
+ * Operates like DBInputFormat, but instead of using LIMIT and OFFSET to demarcate
+ * splits, it tries to generate WHERE clauses which separate the data into roughly
+ * equivalent shards.
+ */
+public class DataDrivenDBInputFormat<T extends DBWritable> extends DBInputFormat<T> {
+
+    /** Field LOG */
+    private static final Logger LOG = LoggerFactory.getLogger(DataDrivenDBInputFormat.class);
+
+    /**
+     * A RecordReader that reads records from a SQL table,
+     * using data-driven WHERE clause splits.
+     * Emits LongWritables containing the record number as
+     * key and DBWritables as value.
+     */
+    public class DataDrivenDBRecordReader implements RecordReader<LongWritable, T> {
+        private ResultSet results;
+        private Statement statement;
+        private Class<T> inputClass;
+        private JobConf job;
+        private DataDrivenDBInputSplit split;
+        private long pos = 0;
+
+        /**
+         * @param split The InputSplit to read data for
+         * @throws SQLException
+         */
+        protected DataDrivenDBRecordReader(DataDrivenDBInputSplit split, Class<T> inputClass, JobConf job)
+            throws SQLException, IOException {
+            this.inputClass = inputClass;
+            this.split = split;
+            this.job = job;
+
+            statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+
+            //statement.setFetchSize(Integer.MIN_VALUE);
+            String query = getSelectQuery();
+            try {
+                LOG.info(query);
+                results = statement.executeQuery(query);
+                LOG.info("done executing select query");
+            } catch (SQLException exception) {
+                LOG.error("unable to execute select query: " + query, exception);
+                throw new IOException("unable to execute select query: " + query, exception);
+            }
+        }
+
+        protected String getSelectQuery() {
+            LOG.info("Executing select query");
+            StringBuilder query = new StringBuilder();
+
+            // Build the WHERE clauses associated with the data split first.
+            // We need them in both branches of this function.
+            StringBuilder conditionClauses = new StringBuilder();
+            conditionClauses.append("( ").append(split.getLowerClause());
+            conditionClauses.append(" ) AND ( ").append(split.getUpperClause());
+            conditionClauses.append(" )");
+
+            query.append("SELECT ");
+
+            for (int i = 0; i < fieldNames.length; i++) {
+                query.append(fieldNames[i]);
+
+                if (i != fieldNames.length - 1)
+                    query.append(", ");
+            }
+
+            query.append(" FROM ").append(tableName);
+
+            if (dbConf.getTableAlias()) {
+                query.append(" AS ").append(tableName); //in hsqldb this is necessary
+            }
+
+            query.append(" WHERE ");
+            if (conditions != null && conditions.length() > 0) {
+                // Put the user's conditions first.
+                query.append("( ").append(conditions).append(" ) AND ");
+            }
+
+            // Now append the conditions associated with our split.
+            query.append(conditionClauses.toString());
+
+            String orderBy = dbConf.getInputOrderBy();
+
+            if (orderBy != null && orderBy.length() > 0)
+                query.append(" ORDER BY ").append(orderBy);
+
+            return query.toString();
+        }
+
+        /** {@inheritDoc} */
+        public void close() throws IOException {
+            try {
+                connection.commit();
+                results.close();
+                statement.close();
+            } catch (SQLException exception) {
+                throw new IOException("unable to commit and close", exception);
+            }
+        }
+
+        /** {@inheritDoc} */
+        public LongWritable createKey() {
+            return new LongWritable();
+        }
+
+        /** {@inheritDoc} */
+        public T createValue() {
+            return ReflectionUtils.newInstance(inputClass, job);
+        }
+
+        /** {@inheritDoc} */
+        public long getPos() throws IOException {
+            return pos;
+        }
+
+        /** {@inheritDoc} */
+        public float getProgress() throws IOException {
+            return isDone()? 1.0f : 0.0f;
+        }
+
+        /**
+         * @return true if nextKeyValue() would return false.
+         */
+        protected boolean isDone() {
+            try {
+                return this.results != null && results.isAfterLast();
+            } catch (SQLException sqlE) {
+                return true;
+            }
+        }
+
+        /** {@inheritDoc} */
+        public boolean next(LongWritable key, T value) throws IOException {
+            try {
+                if (!results.next())
+                    return false;
+
+                // Set the key field value as the output key value
+                key.set(pos + split.getStart());
+
+                value.readFields(results);
+
+                pos++;
+            } catch (SQLException exception) {
+                throw new IOException("unable to get next value", exception);
+            }
+
+            return true;
+        }
+    }
+
+    /**
+     * A InputSplit that spans a set of rows
+     */
+    public static class DataDrivenDBInputSplit extends DBInputSplit {
+
+        private String lowerBoundClause;
+        private String upperBoundClause;
+
+        /**
+         * Default Constructor
+         */
+        public DataDrivenDBInputSplit() {
+        }
+
+        /**
+         * Convenience Constructor
+         * @param lower the string to be put in the WHERE clause to guard on the 'lower' end
+         * @param upper the string to be put in the WHERE clause to guard on the 'upper' end
+         */
+        public DataDrivenDBInputSplit(final String lower, final String upper) {
+            this.lowerBoundClause = lower;
+            this.upperBoundClause = upper;
+        }
+
+        /**
+         * @return The total row count in this split
+         */
+        public long getLength() throws IOException {
+            return 0; // unfortunately, we don't know this.
+        }
+
+        /** {@inheritDoc} */
+        public void readFields(DataInput input) throws IOException {
+            this.lowerBoundClause = Text.readString(input);
+            this.upperBoundClause = Text.readString(input);
+        }
+
+        /** {@inheritDoc} */
+        public void write(DataOutput output) throws IOException {
+            Text.writeString(output, this.lowerBoundClause);
+            Text.writeString(output, this.upperBoundClause);
+        }
+
+        public String getLowerClause() {
+            return lowerBoundClause;
+        }
+
+        public String getUpperClause() {
+            return upperBoundClause;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @SuppressWarnings("unchecked")
+    public RecordReader<LongWritable, T> getRecordReader(InputSplit split, JobConf job,
+                                                         Reporter reporter) throws IOException {
+        Class inputClass = dbConf.getInputClass();
+        try {
+            return new DataDrivenDBRecordReader((DataDrivenDBInputSplit) split, inputClass, job);
+        } catch (SQLException exception) {
+            throw new IOException(exception.getMessage(), exception);
+        }
+    }
+
+    /**
+     * @return the DBSplitter implementation to use to divide the table/query into InputSplits.
+     */
+    protected DBSplitter getSplitter(int sqlDataType) {
+        switch (sqlDataType) {
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return new BigDecimalSplitter();
+
+            case Types.BIT:
+            case Types.BOOLEAN:
+                return new BooleanSplitter();
+
+            case Types.INTEGER:
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.BIGINT:
+                return new IntegerSplitter();
+
+            case Types.REAL:
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return new FloatSplitter();
+
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                return new TextSplitter();
+
+            case Types.DATE:
+            case Types.TIME:
+            case Types.TIMESTAMP:
+                return new DateSplitter();
+
+            default:
+                // TODO: Support BINARY, VARBINARY, LONGVARBINARY, DISTINCT, CLOB, BLOB, ARRAY
+                // STRUCT, REF, DATALINK, and JAVA_OBJECT.
+                return null;
+        }
+    }
+
+    public InputSplit[] getSplits(JobConf job, int chunks) throws IOException {
+        int targetNumTasks = dbConf.getMaxConcurrentReadsNum();
+        if (1 == targetNumTasks) {
+            // There's no need to run a bounding vals query; just return a split
+            // that separates nothing. This can be considerably more optimal for a
+            // large table with no index.
+            List<InputSplit> singletonSplit = new ArrayList<InputSplit>();
+            singletonSplit.add(new DataDrivenDBInputSplit("1=1", "1=1"));
+            return singletonSplit.toArray(new InputSplit[1]);
+        }
+
+        ResultSet results = null;
+        Statement statement = null;
+        try {
+            statement = connection.createStatement();
+
+            String boundingValsQuery = getBoundingValsQuery();
+
+            LOG.info("Getting splits: " + boundingValsQuery);
+            results = statement.executeQuery(boundingValsQuery);
+            results.next();
+
+            // Based on the type of the results, use a different mechanism
+            // for interpolating split points (i.e., numeric splits, text splits,
+            // dates, etc.)
+            int sqlDataType = results.getMetaData().getColumnType(1);
+            DBSplitter splitter = getSplitter(sqlDataType);
+            if (null == splitter) {
+                throw new IOException("Unknown SQL data type: " + sqlDataType);
+            }
+            List<InputSplit> splits = splitter.split(job, results, dbConf.getInputOrderBy());
+            return splits.toArray(new InputSplit[splits.size()]);
+        } catch (SQLException e) {
+            throw new IOException(e.getMessage());
+        } finally {
+            // More-or-less ignore SQL exceptions here, but log in case we need it.
+            try {
+                if (null != results) {
+                    results.close();
+                }
+            } catch (SQLException se) {
+                LOG.debug("SQLException closing resultset: " + se.toString());
+            }
+
+            try {
+                if (null != statement) {
+                    statement.close();
+                }
+            } catch (SQLException se) {
+                LOG.debug("SQLException closing statement: " + se.toString());
+            }
+        }
+    }
+
+    /**
+     * @return a query which returns the minimum and maximum values for
+     * the order-by column.
+     *
+     * The min value should be in the first column, and the
+     * max value should be in the second column of the results.
+     */
+    protected String getBoundingValsQuery() {
+        // Auto-generate one based on the table name we've been provided with.
+        StringBuilder query = new StringBuilder();
+
+        String splitCol = dbConf.getInputOrderBy();
+        query.append("SELECT MIN(").append(splitCol).append("), ");
+        query.append("MAX(").append(splitCol).append(") FROM ");
+        query.append(dbConf.getInputTableName());
+        String conditions = dbConf.getInputConditions();
+        if (null != conditions) {
+            query.append(" WHERE ( " + conditions + " )");
+        }
+
+        return query.toString();
+    }
+
+    /** {@inheritDoc} */
+    public static void setInput(JobConf job, Class<? extends DBWritable> inputClass,
+                                String tableName, String conditions, String orderBy, long limit, int concurrentReads,
+                                Boolean tableAlias, String... fieldNames) {
+        DBInputFormat.setInput(job, inputClass, tableName, conditions, orderBy, limit, concurrentReads, tableAlias, fieldNames);
+        job.setInputFormat(DataDrivenDBInputFormat.class);
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/DataDrivenDBInputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DataDrivenDBInputFormat.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/DateSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DateSplitter.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over date/time values.
+ * Make use of logic from IntegerSplitter, since date/time are just longs
+ * in Java.
+ */
+public class DateSplitter extends IntegerSplitter {
+
+    private static final Log LOG = LogFactory.getLog(DateSplitter.class);
+
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        long minVal;
+        long maxVal;
+
+        int sqlDataType = results.getMetaData().getColumnType(1);
+        minVal = resultSetColToLong(results, 1, sqlDataType);
+        maxVal = resultSetColToLong(results, 2, sqlDataType);
+
+        String lowClausePrefix = colName + " >= ";
+        String highClausePrefix = colName + " < ";
+
+        int numSplits = conf.getInt(DBConfiguration.CONCURRENT_READS_PROPERTY, 1);
+        if (numSplits < 1) {
+            numSplits = 1;
+        }
+
+        if (minVal == Long.MIN_VALUE && maxVal == Long.MIN_VALUE) {
+            // The range of acceptable dates is NULL to NULL. Just create a single split.
+            List<InputSplit> splits = new ArrayList<InputSplit>();
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        // Gather the split point integers
+        List<Long> splitPoints = split(numSplits, minVal, maxVal);
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        // Turn the split points into a set of intervals.
+        long start = splitPoints.get(0);
+        Date startDate = longToDate(start, sqlDataType);
+        if (sqlDataType == Types.TIMESTAMP) {
+            // The lower bound's nanos value needs to match the actual lower-bound nanos.
+            try {
+                ((java.sql.Timestamp) startDate).setNanos(results.getTimestamp(1).getNanos());
+            } catch (NullPointerException npe) {
+                // If the lower bound was NULL, we'll get an NPE; just ignore it and don't set nanos.
+            }
+        }
+
+        for (int i = 1; i < splitPoints.size(); i++) {
+            long end = splitPoints.get(i);
+            Date endDate = longToDate(end, sqlDataType);
+
+            if (i == splitPoints.size() - 1) {
+                if (sqlDataType == Types.TIMESTAMP) {
+                    // The upper bound's nanos value needs to match the actual upper-bound nanos.
+                    try {
+                        ((java.sql.Timestamp) endDate).setNanos(results.getTimestamp(2).getNanos());
+                    } catch (NullPointerException npe) {
+                        // If the upper bound was NULL, we'll get an NPE; just ignore it and don't set nanos.
+                    }
+                }
+                // This is the last one; use a closed interval.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + dateToString(startDate),
+                        colName + " <= " + dateToString(endDate)));
+            } else {
+                // Normal open-interval case.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + dateToString(startDate),
+                        highClausePrefix + dateToString(endDate)));
+            }
+
+            start = end;
+            startDate = endDate;
+        }
+
+        if (minVal == Long.MIN_VALUE || maxVal == Long.MIN_VALUE) {
+            // Add an extra split to handle the null case that we saw.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+        }
+
+        return splits;
+    }
+
+    /** Retrieve the value from the column in a type-appropriate manner and return
+     its timestamp since the epoch. If the column is null, then return Long.MIN_VALUE.
+     This will cause a special split to be generated for the NULL case, but may also
+     cause poorly-balanced splits if most of the actual dates are positive time
+     since the epoch, etc.
+     */
+    private long resultSetColToLong(ResultSet rs, int colNum, int sqlDataType) throws SQLException {
+        try {
+            switch (sqlDataType) {
+                case Types.DATE:
+                    return rs.getDate(colNum).getTime();
+                case Types.TIME:
+                    return rs.getTime(colNum).getTime();
+                case Types.TIMESTAMP:
+                    return rs.getTimestamp(colNum).getTime();
+                default:
+                    throw new SQLException("Not a date-type field");
+            }
+        } catch (NullPointerException npe) {
+            // null column. return minimum long value.
+            LOG.warn("Encountered a NULL date in the split column. Splits may be poorly balanced.");
+            return Long.MIN_VALUE;
+        }
+    }
+
+    /**  Parse the long-valued timestamp into the appropriate SQL date type. */
+    private Date longToDate(long val, int sqlDataType) {
+        switch (sqlDataType) {
+            case Types.DATE:
+                return new java.sql.Date(val);
+            case Types.TIME:
+                return new java.sql.Time(val);
+            case Types.TIMESTAMP:
+                return new java.sql.Timestamp(val);
+            default: // Shouldn't ever hit this case.
+                return null;
+        }
+    }
+
+    /**
+     * Given a Date 'd', format it as a string for use in a SQL date
+     * comparison operation.
+     * @param d the date to format.
+     * @return the string representing this date in SQL with any appropriate
+     * quotation characters, etc.
+     */
+    protected String dateToString(Date d) {
+        return "'" + d.toString() + "'";
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/DateSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DateSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/FloatSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/FloatSplitter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over floating-point values.
+ */
+public class FloatSplitter implements DBSplitter {
+
+    private static final Log LOG = LogFactory.getLog(FloatSplitter.class);
+
+    private static final double MIN_INCREMENT = 10000 * Double.MIN_VALUE;
+
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        LOG.warn("Generating splits for a floating-point index column. Due to the");
+        LOG.warn("imprecise representation of floating-point values in Java, this");
+        LOG.warn("may result in an incomplete import.");
+        LOG.warn("You are strongly encouraged to choose an integral split column.");
+
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        if (results.getString(1) == null && results.getString(2) == null) {
+            // Range is null to null. Return a null split accordingly.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        double minVal = results.getDouble(1);
+        double maxVal = results.getDouble(2);
+
+        // Use this as a hint. May need an extra task if the size doesn't
+        // divide cleanly.
+        int numSplits = conf.getInt(DBConfiguration.CONCURRENT_READS_PROPERTY, 1);
+        double splitSize = (maxVal - minVal) / (double) numSplits;
+
+        if (splitSize < MIN_INCREMENT) {
+            splitSize = MIN_INCREMENT;
+        }
+
+        String lowClausePrefix = colName + " >= ";
+        String highClausePrefix = colName + " < ";
+
+        double curLower = minVal;
+        double curUpper = curLower + splitSize;
+
+        while (curUpper < maxVal) {
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    lowClausePrefix + Double.toString(curLower),
+                    highClausePrefix + Double.toString(curUpper)));
+
+            curLower = curUpper;
+            curUpper += splitSize;
+        }
+
+        // Catch any overage and create the closed interval for the last split.
+        if (curLower <= maxVal || splits.size() == 1) {
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    lowClausePrefix + Double.toString(curUpper),
+                    colName + " <= " + Double.toString(maxVal)));
+        }
+
+        if (results.getString(1) == null || results.getString(2) == null) {
+            // At least one extrema is null; add a null split.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+        }
+
+        return splits;
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/FloatSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/FloatSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/IntegerSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/IntegerSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/jvm/com/twitter/maple/jdbc/db/IntegerSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/IntegerSplitter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over integer values.
+ */
+public class IntegerSplitter implements DBSplitter {
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        long minVal = results.getLong(1);
+        long maxVal = results.getLong(2);
+
+        String lowClausePrefix = colName + " >= ";
+        String highClausePrefix = colName + " < ";
+
+        int numSplits = conf.getInt(DBConfiguration.CONCURRENT_READS_PROPERTY, 1);
+        if (numSplits < 1) {
+            numSplits = 1;
+        }
+
+        if (results.getString(1) == null && results.getString(2) == null) {
+            // Range is null to null. Return a null split accordingly.
+            List<InputSplit> splits = new ArrayList<InputSplit>();
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        // Get all the split points together.
+        List<Long> splitPoints = split(numSplits, minVal, maxVal);
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        // Turn the split points into a set of intervals.
+        long start = splitPoints.get(0);
+        for (int i = 1; i < splitPoints.size(); i++) {
+            long end = splitPoints.get(i);
+
+            if (i == splitPoints.size() - 1) {
+                // This is the last one; use a closed interval.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + Long.toString(start),
+                        colName + " <= " + Long.toString(end)));
+            } else {
+                // Normal open-interval case.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + Long.toString(start),
+                        highClausePrefix + Long.toString(end)));
+            }
+
+            start = end;
+        }
+
+        if (results.getString(1) == null || results.getString(2) == null) {
+            // At least one extrema is null; add a null split.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+        }
+
+        return splits;
+    }
+
+    /**
+     * Returns a list of longs one element longer than the list of input splits.
+     * This represents the boundaries between input splits.
+     * All splits are open on the top end, except the last one.
+     *
+     * So the list [0, 5, 8, 12, 18] would represent splits capturing the intervals:
+     *
+     * [0, 5)
+     * [5, 8)
+     * [8, 12)
+     * [12, 18] note the closed interval for the last split.
+     */
+    List<Long> split(long numSplits, long minVal, long maxVal)
+            throws SQLException {
+
+        List<Long> splits = new ArrayList<Long>();
+
+        // Use numSplits as a hint. May need an extra task if the size doesn't
+        // divide cleanly.
+
+        long splitSize = (maxVal - minVal) / numSplits;
+        if (splitSize < 1) {
+            splitSize = 1;
+        }
+
+        long curVal = minVal;
+
+        while (curVal <= maxVal) {
+            splits.add(curVal);
+            curVal += splitSize;
+        }
+
+        if (splits.get(splits.size() - 1) != maxVal || splits.size() == 1) {
+            // We didn't end on the maxVal. Add that to the end of the list.
+            splits.add(maxVal);
+        }
+
+        return splits;
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/TextSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/TextSplitter.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2009 Concurrent, Inc.
+ *
+ * This work has been released into the public domain
+ * by the copyright holder. This applies worldwide.
+ *
+ * In case this is not legally possible:
+ * The copyright holder grants any entity the right
+ * to use this work for any purpose, without any
+ * conditions, unless such conditions are required by law.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twitter.maple.jdbc.db;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.InputSplit;
+
+/**
+ * Implement DBSplitter over text strings.
+ */
+public class TextSplitter extends BigDecimalSplitter {
+
+    private static final Log LOG = LogFactory.getLog(TextSplitter.class);
+
+    /**
+     * This method needs to determine the splits between two user-provided strings.
+     * In the case where the user's strings are 'A' and 'Z', this is not hard; we
+     * could create two splits from ['A', 'M') and ['M', 'Z'], 26 splits for strings
+     * beginning with each letter, etc.
+     *
+     * If a user has provided us with the strings "Ham" and "Haze", however, we need
+     * to create splits that differ in the third letter.
+     *
+     * The algorithm used is as follows:
+     * Since there are 2**16 unicode characters, we interpret characters as digits in
+     * base 65536. Given a string 's' containing characters s_0, s_1 .. s_n, we interpret
+     * the string as the number: 0.s_0 s_1 s_2.. s_n in base 65536. Having mapped the
+     * low and high strings into floating-point values, we then use the BigDecimalSplitter
+     * to establish the even split points, then map the resulting floating point values
+     * back into strings.
+     */
+    public List<InputSplit> split(Configuration conf, ResultSet results, String colName)
+            throws SQLException {
+
+        LOG.warn("Generating splits for a textual index column.");
+        LOG.warn("If your database sorts in a case-insensitive order, "
+                + "this may result in a partial import or duplicate records.");
+        LOG.warn("You are strongly encouraged to choose an integral split column.");
+
+        String minString = results.getString(1);
+        String maxString = results.getString(2);
+
+        boolean minIsNull = false;
+
+        // If the min value is null, switch it to an empty string instead for purposes
+        // of interpolation. Then add [null, null] as a special case split.
+        if (null == minString) {
+            minString = "";
+            minIsNull = true;
+        }
+
+        if (null == maxString) {
+            // If the max string is null, then the min string has to be null too.
+            // Just return a special split for this case.
+            List<InputSplit> splits = new ArrayList<InputSplit>();
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+            return splits;
+        }
+
+        // Use this as a hint. May need an extra task if the size doesn't
+        // divide cleanly.
+        int numSplits = conf.getInt(DBConfiguration.CONCURRENT_READS_PROPERTY, 1);
+
+        String lowClausePrefix = colName + " >= '";
+        String highClausePrefix = colName + " < '";
+
+        // If there is a common prefix between minString and maxString, establish it
+        // and pull it out of minString and maxString.
+        int maxPrefixLen = Math.min(minString.length(), maxString.length());
+        int sharedLen;
+        for (sharedLen = 0; sharedLen < maxPrefixLen; sharedLen++) {
+            char c1 = minString.charAt(sharedLen);
+            char c2 = maxString.charAt(sharedLen);
+            if (c1 != c2) {
+                break;
+            }
+        }
+
+        // The common prefix has length 'sharedLen'. Extract it from both.
+        String commonPrefix = minString.substring(0, sharedLen);
+        minString = minString.substring(sharedLen);
+        maxString = maxString.substring(sharedLen);
+
+        List<String> splitStrings = split(numSplits, minString, maxString, commonPrefix);
+        List<InputSplit> splits = new ArrayList<InputSplit>();
+
+        // Convert the list of split point strings into an actual set of InputSplits.
+        String start = splitStrings.get(0);
+        for (int i = 1; i < splitStrings.size(); i++) {
+            String end = splitStrings.get(i);
+
+            if (i == splitStrings.size() - 1) {
+                // This is the last one; use a closed interval.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + start + "'", colName + " <= '" + end + "'"));
+            } else {
+                // Normal open-interval case.
+                splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                        lowClausePrefix + start + "'", highClausePrefix + end + "'"));
+            }
+        }
+
+        if (minIsNull) {
+            // Add the special null split at the end.
+            splits.add(new DataDrivenDBInputFormat.DataDrivenDBInputSplit(
+                    colName + " IS NULL", colName + " IS NULL"));
+        }
+
+        return splits;
+    }
+
+    List<String> split(int numSplits, String minString, String maxString, String commonPrefix)
+            throws SQLException {
+
+        BigDecimal minVal = stringToBigDecimal(minString);
+        BigDecimal maxVal = stringToBigDecimal(maxString);
+
+        List<BigDecimal> splitPoints = split(new BigDecimal(numSplits), minVal, maxVal);
+        List<String> splitStrings = new ArrayList<String>();
+
+        // Convert the BigDecimal splitPoints into their string representations.
+        for (BigDecimal bd : splitPoints) {
+            splitStrings.add(commonPrefix + bigDecimalToString(bd));
+        }
+
+        // Make sure that our user-specified boundaries are the first and last entries
+        // in the array.
+        if (splitStrings.size() == 0 || !splitStrings.get(0).equals(commonPrefix + minString)) {
+            splitStrings.add(0, commonPrefix + minString);
+        }
+        if (splitStrings.size() == 1
+                || !splitStrings.get(splitStrings.size() - 1).equals(commonPrefix + maxString)) {
+            splitStrings.add(commonPrefix + maxString);
+        }
+
+        return splitStrings;
+    }
+
+    private final static BigDecimal ONE_PLACE = new BigDecimal(65536);
+
+    // Maximum number of characters to convert. This is to prevent rounding errors
+    // or repeating fractions near the very bottom from getting out of control. Note
+    // that this still gives us a huge number of possible splits.
+    private final static int MAX_CHARS = 8;
+
+    /**
+     * Return a BigDecimal representation of string 'str' suitable for use
+     * in a numerically-sorting order.
+     */
+    BigDecimal stringToBigDecimal(String str) {
+        BigDecimal result = BigDecimal.ZERO;
+        BigDecimal curPlace = ONE_PLACE; // start with 1/65536 to compute the first digit.
+
+        int len = Math.min(str.length(), MAX_CHARS);
+
+        for (int i = 0; i < len; i++) {
+            int codePoint = str.codePointAt(i);
+            result = result.add(tryDivide(new BigDecimal(codePoint), curPlace));
+            // advance to the next less significant place. e.g., 1/(65536^2) for the second char.
+            curPlace = curPlace.multiply(ONE_PLACE);
+        }
+
+        return result;
+    }
+
+    /**
+     * Return the string encoded in a BigDecimal.
+     * Repeatedly multiply the input value by 65536; the integer portion after such a multiplication
+     * represents a single character in base 65536. Convert that back into a char and create a
+     * string out of these until we have no data left.
+     */
+    String bigDecimalToString(BigDecimal bd) {
+        BigDecimal cur = bd.stripTrailingZeros();
+        StringBuilder sb = new StringBuilder();
+
+        for (int numConverted = 0; numConverted < MAX_CHARS; numConverted++) {
+            cur = cur.multiply(ONE_PLACE);
+            int curCodePoint = cur.intValue();
+            if (0 == curCodePoint) {
+                break;
+            }
+
+            cur = cur.subtract(new BigDecimal(curCodePoint));
+            sb.append(Character.toChars(curCodePoint));
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/jvm/com/twitter/maple/jdbc/db/TextSplitter.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/TextSplitter.java
@@ -10,6 +10,8 @@
  * conditions, unless such conditions are required by law.
  */
 /**
+ * Copyright 2012 The Apache Software Foundation
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
This is a rough port from Hadoop with the minimal amounts of changes needed. I also added a builder to JDBCScheme to help with the various forms of constructors. This can definitely be done more cleanly when moved to https://github.com/Cascading/cascading-jdbc.

See user group discussion: https://groups.google.com/forum/#!topic/cascading-user/HbJdrLKOLH8
