### PR TITLE
Add replaceOnInsert functionality to maple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ A collection of useful Cascading taps.
 
 Maple uses [Leiningen](https://github.com/technomancy/leiningen/) 2.0 to build.
 
-1. lein deps
-2. lein compile
-3. lein uberjar
+1. lein with-profile dev deps
+2. lein with-profile dev uberjar
+3. lein with-profile dev install
 
-The above should build a jar with all dependencies.
+The above should build a jar with all dependencies. And then `install` will add this jar to your
+local maven repository in ~/.m2/repositories.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,6 @@
 (defproject com.twitter/maple "0.3.1-SNAPSHOT"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
-  :javac-target "1.6"
-  :javac-options ["-Xlint:deprecation"]
   :url "http://github.com/Cascading/maple"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject com.twitter/maple "0.3.1-SNAPSHOT"
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
+  :javac-target "1.6"
+  :javac-options ["-Xlint:deprecation"]
   :url "http://github.com/Cascading/maple"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -60,6 +60,11 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     private String countQuery;
     private long limit = -1;
     private Boolean tableAlias = true;
+    /**
+     * If true, will use mysql's 'REPLACE INTO' to replace existing rows with the same key as new
+     * rows. See http://dev.mysql.com/doc/refman/5.0/en/replace.html.
+     */
+    private Boolean replaceOnInsert = false;
 
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.
@@ -174,16 +179,27 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.
      *
+     * Specify replaceOnInsert if you want to change the default insert behaviro.
+     *
      * @param inputFormatClass  of type Class<? extends DBInputFormat>
      * @param outputFormatClass of type Class<? extends DBOutputFormat>
      * @param columns           of type String[]
      * @param orderBy           of type String[]
      * @param conditions        of type String
      * @param updateBy          of type String[]
+     * @param replaceOnInsert   boolean
      */
-    public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String conditions, String[] updateBy )
-    {
+    public JDBCScheme(
+        Class<? extends DBInputFormat> inputFormatClass,
+        Class<? extends DBOutputFormat> outputFormatClass,
+        String[] columns,
+        String[] orderBy,
+        String conditions,
+        String[] updateBy,
+        boolean replaceOnInsert
+    ) {
         this( inputFormatClass, outputFormatClass, columns, orderBy, conditions, -1, updateBy );
+        this.replaceOnInsert = replaceOnInsert;
     }
 
     /**
@@ -214,7 +230,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( Class<? extends DBInputFormat> inputFormatClass, Class<? extends DBOutputFormat> outputFormatClass, String[] columns, String[] orderBy, String[] updateBy )
     {
-        this( inputFormatClass, outputFormatClass, columns, orderBy, null, updateBy );
+        this( inputFormatClass, outputFormatClass, columns, orderBy, null, updateBy, false );
     }
 
     /**
@@ -295,7 +311,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( String[] columns, String[] orderBy, String conditions )
     {
-        this( null, null, columns, orderBy, conditions, null );
+        this( null, null, columns, orderBy, conditions, null, false);
     }
 
     public JDBCScheme( Fields columnFields, String[] columns, String[] orderBy, String conditions )
@@ -376,7 +392,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      */
     public JDBCScheme( String[] columns, String conditions )
     {
-        this( null, null, columns, null, conditions, null );
+        this( null, null, columns, null, conditions, null, false);
     }
 
     /**
@@ -593,7 +609,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
 
         String tableName = ( (JDBCTap) tap ).getTableName();
         int batchSize = ( (JDBCTap) tap ).getBatchSize();
-        DBOutputFormat.setOutput( conf, DBOutputFormat.class, tableName, columns, updateBy, batchSize );
+        DBOutputFormat.setOutput( conf, DBOutputFormat.class, tableName, columns, updateBy, batchSize, replaceOnInsert );
 
         if( outputFormatClass != null )
             conf.setOutputFormat( outputFormatClass );

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -64,7 +64,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
      * If true, will use mysql's 'REPLACE INTO' to replace existing rows with the same key as new
      * rows. See http://dev.mysql.com/doc/refman/5.0/en/replace.html.
      */
-    private Boolean replaceOnInsert = false;
+    private boolean replaceOnInsert = false;
 
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -179,7 +179,7 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     /**
      * Constructor JDBCScheme creates a new JDBCScheme instance.
      *
-     * Specify replaceOnInsert if you want to change the default insert behaviro.
+     * Specify replaceOnInsert if you want to change the default insert behavior.
      *
      * @param inputFormatClass  of type Class<? extends DBInputFormat>
      * @param outputFormatClass of type Class<? extends DBOutputFormat>

--- a/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
+++ b/src/jvm/com/twitter/maple/jdbc/JDBCScheme.java
@@ -61,8 +61,8 @@ public class JDBCScheme extends Scheme<JobConf, RecordReader, OutputCollector, O
     private long limit = -1;
     private Boolean tableAlias = true;
     /**
-     * If true, will use mysql's 'REPLACE INTO' to replace existing rows with the same key as new
-     * rows. See http://dev.mysql.com/doc/refman/5.0/en/replace.html.
+     * If true, will use mysql's 'ON DUPLICATE KEY UPDATE' to update existing rows with the same key
+     * with the new data. See http://dev.mysql.com/doc/refman/5.0/en/insert-on-duplicate.html.
      */
     private boolean replaceOnInsert = false;
 

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -83,6 +83,9 @@ public class DBConfiguration {
     /** Boolean to include table name alias in the input SELECT statement */
     public static final String INPUT_TABLE_ALIAS = "mapred.jdbc.input.table.alias";
 
+    /** Boolean to use REPLACE INTO instead of INSERT INTO when outputting tuples to MySQL. */
+    public static final String REPLACE_ON_INSERT = "mapred.jdbc.output.replace.on.insert";
+
     /** Output table name */
     public static final String OUTPUT_TABLE_NAME_PROPERTY = "mapred.jdbc.output.table.name";
 
@@ -203,6 +206,14 @@ public class DBConfiguration {
 
     void setTableAlias(Boolean alias) {
         job.setBoolean(DBConfiguration.INPUT_TABLE_ALIAS, alias);
+    }
+
+    Boolean getReplaceOnInsert() {
+      return job.getBoolean(DBConfiguration.REPLACE_ON_INSERT, false);
+    }
+
+    void setReplaceOnInsert(Boolean replaceOnInsert) {
+      job.setBoolean(DBConfiguration.REPLACE_ON_INSERT, replaceOnInsert);
     }
 
     String getInputQuery() {

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -208,11 +208,11 @@ public class DBConfiguration {
         job.setBoolean(DBConfiguration.INPUT_TABLE_ALIAS, alias);
     }
 
-    Boolean getReplaceOnInsert() {
+    boolean getReplaceOnInsert() {
       return job.getBoolean(DBConfiguration.REPLACE_ON_INSERT, false);
     }
 
-    void setReplaceOnInsert(Boolean replaceOnInsert) {
+    void setReplaceOnInsert(boolean replaceOnInsert) {
       job.setBoolean(DBConfiguration.REPLACE_ON_INSERT, replaceOnInsert);
     }
 

--- a/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBConfiguration.java
@@ -83,7 +83,7 @@ public class DBConfiguration {
     /** Boolean to include table name alias in the input SELECT statement */
     public static final String INPUT_TABLE_ALIAS = "mapred.jdbc.input.table.alias";
 
-    /** Boolean to use REPLACE INTO instead of INSERT INTO when outputting tuples to MySQL. */
+    /** Boolean to use ON DUPLICATE KEY UPDATE for INSERTs when outputting tuples to MySQL. */
     public static final String REPLACE_ON_INSERT = "mapred.jdbc.output.replace.on.insert";
 
     /** Output table name */

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -208,36 +208,33 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
         }
 
         StringBuilder query = new StringBuilder();
-
-        if (replaceOnInsert) {
-          query.append("REPLACE INTO ").append(table);
-        } else {
-          query.append("INSERT INTO ").append(table);
-        }
+        query.append("INSERT INTO ").append(table);
 
         if (fieldNames.length > 0 && fieldNames[0] != null) {
             query.append(" (");
-
             for (int i = 0; i < fieldNames.length; i++) {
                 query.append(fieldNames[i]);
-
                 if (i != fieldNames.length - 1) { query.append(","); }
             }
-
             query.append(")");
-
         }
 
         query.append(" VALUES (");
-
         for (int i = 0; i < fieldNames.length; i++) {
             query.append("?");
-
             if (i != fieldNames.length - 1) { query.append(","); }
         }
+        query.append(")");
 
-        query.append(");");
+        if (replaceOnInsert) {
+          query.append(" ON DUPLICATE KEY UPDATE ");
+          for (int i = 0; i < fieldNames.length; i++) {
+              query.append(String.format("%s=VALUES(%s)", fieldNames[i], fieldNames[i]));
+              if (i != fieldNames.length - 1) { query.append(","); }
+          }
+        }
 
+        query.append(";");
         return query.toString();
     }
 

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -197,7 +197,7 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
      * @param table      the table to insert into
      * @param fieldNames the fields to insert into. If field names are unknown, supply an array of
      *                   nulls.
-     * @param replaceOnInsert if true, uses "REPLACE INTO" instead of "INSERT INTO"
+     * @param replaceOnInsert if true, uses "ON DUPLICATE KEY UPDATE" for the insert statement.
      */
     protected String constructInsertQuery(
       String table,

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -205,7 +205,8 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
 
         StringBuilder query = new StringBuilder();
 
-        query.append("INSERT INTO ").append(table);
+        // query.append("INSERT INTO ").append(table);
+        query.append("REPLACE INTO ").append(table);
 
         if (fieldNames.length > 0 && fieldNames[0] != null) {
             query.append(" (");
@@ -317,6 +318,12 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
             throw new IOException("unable to create statement for: " + sqlUpdate, exception);
         }
 
+        if (insertPreparedStatement != null) {
+          LOG.info("Executing insert statement:\n " + sqlInsert);
+        }
+        if (updatePreparedStatement != null) {
+          LOG.info("Executing update statement:\n " + sqlUpdate);
+        }
         return new DBRecordWriter(connection, insertPreparedStatement, updatePreparedStatement, batchStatements);
     }
 
@@ -339,9 +346,19 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
      * @param dbOutputFormatClass
      * @param tableName           The table to insert data into
      * @param fieldNames          The field names in the table. If unknown, supply the appropriate
+     * @param updateFields
+     * @param batchSize
+     * @param replaceOnInsert     Boolean which says whether inserts should replace.
      */
-    public static void setOutput(JobConf job, Class<? extends DBOutputFormat> dbOutputFormatClass,
-        String tableName, String[] fieldNames, String[] updateFields, int batchSize) {
+    public static void setOutput(
+        JobConf job,
+        Class<? extends DBOutputFormat> dbOutputFormatClass,
+        String tableName,
+        String[] fieldNames,
+        String[] updateFields,
+        int batchSize,
+        boolean replaceOnInsert
+    ) {
         if (dbOutputFormatClass == null) { job.setOutputFormat(DBOutputFormat.class); } else {
             job.setOutputFormat(dbOutputFormatClass);
         }
@@ -354,6 +371,7 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
 
         dbConf.setOutputTableName(tableName);
         dbConf.setOutputFieldNames(fieldNames);
+        dbConf.setReplaceOnInsert(replaceOnInsert);
 
         if (updateFields != null) { dbConf.setOutputUpdateFieldNames(updateFields); }
 

--- a/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
+++ b/src/jvm/com/twitter/maple/jdbc/db/DBOutputFormat.java
@@ -197,16 +197,23 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
      * @param table      the table to insert into
      * @param fieldNames the fields to insert into. If field names are unknown, supply an array of
      *                   nulls.
+     * @param replaceOnInsert if true, uses "REPLACE INTO" instead of "INSERT INTO"
      */
-    protected String constructInsertQuery(String table, String[] fieldNames) {
+    protected String constructInsertQuery(
+      String table,
+      String[] fieldNames,
+      boolean replaceOnInsert) {
         if (fieldNames == null) {
             throw new IllegalArgumentException("Field names may not be null");
         }
 
         StringBuilder query = new StringBuilder();
 
-        // query.append("INSERT INTO ").append(table);
-        query.append("REPLACE INTO ").append(table);
+        if (replaceOnInsert) {
+          query.append("REPLACE INTO ").append(table);
+        } else {
+          query.append("INSERT INTO ").append(table);
+        }
 
         if (fieldNames.length > 0 && fieldNames[0] != null) {
             query.append(" (");
@@ -292,12 +299,13 @@ public class DBOutputFormat<K extends DBWritable, V> implements OutputFormat<K, 
         String[] fieldNames = dbConf.getOutputFieldNames();
         String[] updateNames = dbConf.getOutputUpdateFieldNames();
         int batchStatements = dbConf.getBatchStatementsNum();
+        boolean replaceOnInsert = dbConf.getReplaceOnInsert();
 
         Connection connection = dbConf.getConnection();
 
         configureConnection(connection);
 
-        String sqlInsert = constructInsertQuery(tableName, fieldNames);
+        String sqlInsert = constructInsertQuery(tableName, fieldNames, replaceOnInsert);
         PreparedStatement insertPreparedStatement;
 
         try {


### PR DESCRIPTION
This updates the INSERT statements that the JDBC tap performs to use "ON DUPLICATE KEY UPDATE" to allow scalding jobs that update existing rows to work. By default, the behavior is to replace all the old values with the new values.

See http://dev.mysql.com/doc/refman/5.0/en/insert-on-duplicate.html for more details.
