### PR TITLE
Use cascading.tuple.Tuple's getObject method instead of get.

### DIFF
--- a/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
+++ b/src/jvm/com/twitter/maple/jdbc/TupleRecord.java
@@ -39,7 +39,7 @@ public class TupleRecord implements DBWritable {
 
     public void write( PreparedStatement statement ) throws SQLException {
         for( int i = 0; i < tuple.size(); i++ )
-            statement.setObject( i + 1, tuple.get( i ) );
+            statement.setObject( i + 1, tuple.getObject( i ) );
     }
 
     public void readFields( ResultSet resultSet ) throws SQLException {


### PR DESCRIPTION
The latter is deprecated and does a cast to java.lang.Comparable which
means that some data types can not be used with Maple's
JDBCTap (e.g. primitive arrays, org.postgresql.util.PGObject, etc).
